### PR TITLE
Handle CORS 

### DIFF
--- a/acceptance/handle-manager/handle-manager-route.yaml
+++ b/acceptance/handle-manager/handle-manager-route.yaml
@@ -46,6 +46,6 @@ spec:
     accessControlAllowMethods:
       - "GET"
     accessControlAllowHeaders: "*"
-    accessControlAllowOriginList: "*"
+    accessControlAllowOrigin: "*"
     accessControlMaxAge: 100
     addVaryHeader: true

--- a/acceptance/handle-manager/handle-manager-route.yaml
+++ b/acceptance/handle-manager/handle-manager-route.yaml
@@ -36,3 +36,16 @@ spec:
     prefixes:
       - /handle-manager
     forceSlash: false
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: dissco-handle-manager-cors-headers
+spec:
+  headers:
+    accessControlAllowMethods:
+      - "GET"
+    accessControlAllowHeaders: "*"
+    accessControlAllowOriginList: "*"
+    accessControlMaxAge: 100
+    addVaryHeader: true

--- a/acceptance/handle-manager/handle-manager-route.yaml
+++ b/acceptance/handle-manager/handle-manager-route.yaml
@@ -26,6 +26,7 @@ spec:
           port: 8080
       middlewares:
         - name: dissco-handle-manager-stripprefix
+        - name: dissco-handle-manager-cors-headers
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware


### PR DESCRIPTION
Allow cors headers on get requests

`accessControlAllowMethods`: indicates which methods can be used during requests
`accessControlAllowHeaders`: indicates which header field names can be used as part of the request
`accessControlAllowOrigin`: indicates whether a resource can be shared by returning different values