### PR TITLE
Karpenter / name usage search

### DIFF
--- a/acceptance/backend/backend-deployment.yaml
+++ b/acceptance/backend/backend-deployment.yaml
@@ -74,6 +74,25 @@ spec:
               value: kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
             - name: application.base-url
               value: https://sandbox.dissco.tech
+            - name: fdo.profile
+              value: https://hdl.handle.net/21.T11148/532ce6796e2828dd2be6
+            - name: fdo.agent
+              value: https://ror.org/0566bfb96
+            - name: fdo.digital-object-type
+              value: https://hdl.handle.net/21.T11148/532ce6796e2828dd2be6
+            - name: token.grant-type
+              value: client_credentials
+            - name: token.id
+              value: demo-api-client
+            - name: token.secret
+              valueFrom:
+                secretKeyRef:
+                  name: aws-secrets
+                  key: handle-endpoint-token
+            - name: endpoint.handle-endpoint
+              value: https://sandbox.dissco.tech/handle-manager/api/v1/pids/
+            - name: endpoint.token-endpoint
+              value: https://login-demo.dissco.eu/auth/realms/dissco/protocol/openid-connect/token
           resources:
             requests:
               memory: "500Mi"

--- a/acceptance/frontend/frontend-deployment.yaml
+++ b/acceptance/frontend/frontend-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: disscover
-          image: public.ecr.aws/dissco/disscover:sha-64809ff
+          image: public.ecr.aws/dissco/disscover:sha-8a7e68a
           ports:
             - containerPort: 3000
           resources:

--- a/elastic-schemas/annotation.json
+++ b/elastic-schemas/annotation.json
@@ -1,43 +1,24 @@
 {
+  "settings": {
+    "index": {
+      "number_of_shards": 5,
+      "number_of_replicas": 1
+    }
+  },
   "mappings": {
-    "dynamic": false,
+    "dynamic": "false",
     "properties": {
-      "ods:id": {
-        "type": "text",
-        "fields": {
-          "keyword": {
-            "type": "keyword",
-            "ignore_above": 64
-          }
-        }
-      },
-      "rdf:type": {
-        "type": "constant_keyword",
-        "value": "Annotation"
-      },
-      "ods:version": {
-        "type": "integer"
-      },
-      "oa:motivation": {
-        "type": "text",
-        "fields": {
-          "keyword": {
-            "type": "keyword",
-            "ignore_above": 64
-          }
-        }
-      },
-      "oa:motivatedBy": {
-        "type": "text",
-        "fields": {
-          "keyword": {
-            "type": "keyword",
-            "ignore_above": 256
-          }
-        }
-      },
-      "oa:target": {
+      "as:generator": {
         "properties": {
+          "foaf:name": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
           "ods:id": {
             "type": "text",
             "fields": {
@@ -52,27 +33,112 @@
             "fields": {
               "keyword": {
                 "type": "keyword",
+                "ignore_above": 64
+              }
+            }
+          }
+        }
+      },
+      "dcterms:created": {
+        "type": "date"
+      },
+      "oa:body": {
+        "properties": {
+          "dcterms:reference": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
                 "ignore_above": 256
               }
             }
           },
+          "oa:value": {
+            "type": "text"
+          },
+          "ods:score": {
+            "type": "float"
+          },
+          "ods:type": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }
+      },
+      "oa:creator": {
+        "properties": {
+          "foaf:name": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "ods:id": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "ods:type": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 64
+              }
+            }
+          }
+        }
+      },
+      "oa:generated": {
+        "type": "date"
+      },
+      "oa:motivatedBy": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "oa:motivation": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 64
+          }
+        }
+      },
+      "oa:target": {
+        "properties": {
           "oa:selector": {
             "properties": {
-              "type": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 64
-                  }
-                }
-              },
-              "field": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
+              "ac:hasRoi": {
+                "properties": {
+                  "ac:heightFrac": {
+                    "type": "float"
+                  },
+                  "ac:widthFrac": {
+                    "type": "float"
+                  },
+                  "ac:xFrac": {
+                    "type": "float"
+                  },
+                  "ac:yFrac": {
+                    "type": "float"
                   }
                 }
               },
@@ -85,57 +151,27 @@
                   }
                 }
               },
-              "ac:hasRoi": {
-                "properties": {
-                  "ac:xFrac": {
-                    "type": "float"
-                  },
-                  "ac:yFrac": {
-                    "type": "float"
-                  },
-                  "ac:widthFrac": {
-                    "type": "float"
-                  },
-                  "ac:heightFrac": {
-                    "type": "float"
+              "field": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "type": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 64
                   }
                 }
               }
             }
-          }
-        }
-      },
-      "oa:body": {
-        "properties": {
-          "ods:type": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
           },
-          "oa:value": {
-            "type": "text"
-          },
-          "dcterms:reference": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "ods:score": {
-            "type": "float"
-          }
-        }
-      },
-      "oa:creator": {
-        "properties": {
-          "ods:type": {
+          "ods:id": {
             "type": "text",
             "fields": {
               "keyword": {
@@ -144,16 +180,7 @@
               }
             }
           },
-          "foaf:name": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "ods:id": {
+          "ods:type": {
             "type": "text",
             "fields": {
               "keyword": {
@@ -167,59 +194,46 @@
       "ods:deletedOn": {
         "type": "date"
       },
-      "dcterms:created": {
-        "type": "date"
-      },
-      "oa:generated": {
-        "type": "date"
-      },
-      "as:generator": {
-        "properties": {
-          "ods:id": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 64
-              }
-            }
-          },
-          "foaf:name": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "ods:type": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 64
-              }
-            }
+      "ods:id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 64
           }
         }
       },
-      "schema.org:aggregateRating": {
+      "ods:version": {
+        "type": "integer"
+      },
+      "rdf:type": {
+        "type": "constant_keyword",
+        "value": "Annotation"
+      },
+      "schema": {
         "properties": {
-          "ods:type": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
+          "org:aggregateRating": {
+            "properties": {
+              "ods:type": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "schema": {
+                "properties": {
+                  "org:ratingCount": {
+                    "type": "integer"
+                  },
+                  "org:ratingValue": {
+                    "type": "float"
+                  }
+                }
               }
             }
-          },
-          "schema.org:ratingCount": {
-            "type": "integer"
-          },
-          "schema.org:ratingValue": {
-            "type": "float"
           }
         }
       }

--- a/elastic-schemas/digital-media-object.json
+++ b/elastic-schemas/digital-media-object.json
@@ -1,141 +1,21 @@
 {
+  "settings": {
+    "index": {
+      "number_of_shards": 5,
+      "number_of_replicas": 1
+    }
+  },
   "mappings": {
-    "dynamic": false,
+    "dynamic": "false",
     "properties": {
       "created": {
         "type": "date"
       },
       "digitalMediaObjectWrapper": {
         "properties": {
-          "ods:type": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 64
-              }
-            }
-          },
           "ods:attributes": {
             "properties": {
-              "ac:accessUri": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 512
-                  }
-                }
-              },
-              "dcterms:creator": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dcterms:format": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dcterms:license": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dcterms:type": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dwc:institutionId": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dwc:institutionName": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "xmpRights:webStatement": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dcterms:description": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 1024
-                  }
-                }
-              },
-              "dcterms:rights": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
               "???:rightsUri": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dcterms:accessRights": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dcterms:rightsHolder": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dcterms:source": {
                 "type": "text",
                 "fields": {
                   "keyword": {
@@ -153,161 +33,18 @@
                   }
                 }
               },
-              "dcterms:created": {
+              "ac:accessUri": {
                 "type": "text",
                 "fields": {
                   "keyword": {
                     "type": "keyword",
                     "ignore_above": 256
-                  }
-                }
-              },
-              "dcterms:modified": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "entityRelationships": {
-                "properties": {
-                  "entityRelationshipType": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "objectEntityIri": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "entityRelationshipDate": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "entityRelationshipOrder": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "entityRelationshipCreatorName": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "entityRelationshipCreatorId": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  }
-                }
-              },
-              "identifiers": {
-                "properties": {
-                  "???:identifierType": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "???:identifierValue": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "???:partOfLabel": {
-                    "type": "boolean"
-                  },
-                  "???:barcodeOrNfc": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "isIdPersistent": {
-                    "type": "boolean"
                   }
                 }
               },
               "assertions": {
                 "properties": {
-                  "???:assertionType": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "???:assertionMadeDate": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "???:assertionEffectiveDate": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "???:assertionValue": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "???:assertionValueNumeric": {
-                    "type": "float"
-                  },
-                  "???:assertionUnit": {
+                  "???:assertionByAgentId": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -325,7 +62,16 @@
                       }
                     }
                   },
-                  "???:assertionByAgentId": {
+                  "???:assertionEffectiveDate": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "???:assertionMadeDate": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -360,11 +106,50 @@
                         "ignore_above": 256
                       }
                     }
+                  },
+                  "???:assertionType": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "???:assertionUnit": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "???:assertionValue": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "???:assertionValueNumeric": {
+                    "type": "float"
                   }
                 }
               },
               "citations": {
                 "properties": {
+                  "???:citationPageNumber": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
                   "???:citationRemarks": {
                     "type": "text",
                     "fields": {
@@ -374,7 +159,7 @@
                       }
                     }
                   },
-                  "dcterms:bibliographicCitation": {
+                  "???:citationType": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -383,7 +168,16 @@
                       }
                     }
                   },
-                  "???:citationPageNumber": {
+                  "???:isPeerReviewed": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "???:referenceIri": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -410,7 +204,7 @@
                       }
                     }
                   },
-                  "???:referenceIri": {
+                  "dcterms:bibliographicCitation": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -418,9 +212,6 @@
                         "ignore_above": 256
                       }
                     }
-                  },
-                  "???:isPeerReviewed": {
-                    "type": "boolean"
                   },
                   "dcterms:creator": {
                     "type": "text",
@@ -459,6 +250,212 @@
                     }
                   }
                 }
+              },
+              "dcterms:accessRights": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:created": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:creator": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:description": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:format": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:license": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:modified": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:rights": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:rightsHolder": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:source": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:type": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dwc:institutionId": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dwc:institutionName": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "entityRelationships": {
+                "properties": {
+                  "entityRelationshipCreatorId": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "entityRelationshipCreatorName": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "entityRelationshipDate": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "entityRelationshipOrder": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "entityRelationshipType": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "objectEntityIri": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  }
+                }
+              },
+              "identifiers": {
+                "properties": {
+                  "???:identifierType": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "???:identifierValue": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  }
+                }
+              },
+              "xmpRights:webStatement": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
               }
             }
           },
@@ -473,6 +470,15 @@
           },
           "ods:originalAttributes": {
             "type": "flattened"
+          },
+          "ods:type": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
           }
         }
       },
@@ -481,12 +487,12 @@
         "fields": {
           "keyword": {
             "type": "keyword",
-            "ignore_above": 64
+            "ignore_above": 256
           }
         }
       },
       "version": {
-        "type": "short"
+        "type": "long"
       }
     }
   }

--- a/elastic-schemas/digital-specimen.json
+++ b/elastic-schemas/digital-specimen.json
@@ -1,6 +1,12 @@
 {
+  "settings": {
+    "index": {
+      "number_of_shards": 5,
+      "number_of_replicas": 1
+    }
+  },
   "mappings": {
-    "dynamic": false,
+    "dynamic": "false",
     "properties": {
       "created": {
         "type": "date"
@@ -11,6 +17,15 @@
             "properties": {
               "citations": {
                 "properties": {
+                  "???:citationPageNumber": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
                   "???:citationRemarks": {
                     "type": "text",
                     "fields": {
@@ -20,7 +35,7 @@
                       }
                     }
                   },
-                  "dcterms:bibliographicCitation": {
+                  "???:citationType": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -29,7 +44,16 @@
                       }
                     }
                   },
-                  "???:citationPageNumber": {
+                  "???:isPeerReviewed": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "???:referenceIri": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -56,7 +80,7 @@
                       }
                     }
                   },
-                  "???:referenceIri": {
+                  "dcterms:bibliographicCitation": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -64,9 +88,6 @@
                         "ignore_above": 256
                       }
                     }
-                  },
-                  "???:isPeerReviewed": {
-                    "type": "boolean"
                   },
                   "dcterms:creator": {
                     "type": "text",
@@ -106,7 +127,52 @@
                   }
                 }
               },
+              "dcterms:accessRights": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:disposition": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:license": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
               "dcterms:modified": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:preparations": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dcterms:rightsHolder": {
                 "type": "text",
                 "fields": {
                   "keyword": {
@@ -133,54 +199,18 @@
                   }
                 }
               },
+              "dwc:datasetName": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
               "dwc:identification": {
                 "properties": {
-                  "???:typeDesignatedBy": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "???:typeDesignationType": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:identificationRemarks": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:identificationReferences": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:identifiedById": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:verbatimIdentification": {
+                  "???:identificationType": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -198,7 +228,16 @@
                       }
                     }
                   },
-                  "???:identificationType": {
+                  "???:typeDesignatedBy": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "???:typeDesignationType": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -225,10 +264,37 @@
                       }
                     }
                   },
+                  "dwc:identificationReferences": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:identificationRemarks": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
                   "dwc:identificationVerificationStatus": {
                     "type": "boolean"
                   },
                   "dwc:identifiedBy": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:identifiedById": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -246,8 +312,44 @@
                       }
                     }
                   },
+                  "dwc:verbatimIdentification": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
                   "taxonIdentifications": {
                     "properties": {
+                      "???:acceptedScientificName": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
+                      "???:taxonSource": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
+                      "dwc:class": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
                       "dwc:family": {
                         "type": "text",
                         "fields": {
@@ -266,16 +368,7 @@
                           }
                         }
                       },
-                      "dwc:namePublishedInYear": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dwc:order": {
+                      "dwc:kingdom": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -293,7 +386,7 @@
                           }
                         }
                       },
-                      "dwc:taxonRank": {
+                      "dwc:namePublishedInYear": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -302,7 +395,7 @@
                           }
                         }
                       },
-                      "???:taxonSource": {
+                      "dwc:nomenclaturalCode": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -311,16 +404,7 @@
                           }
                         }
                       },
-                      "dwc:taxonRemarks": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dwc:kingdom": {
+                      "dwc:order": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -330,24 +414,6 @@
                         }
                       },
                       "dwc:phylum": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dwc:class": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dwc:subfamily": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -383,25 +449,7 @@
                           }
                         }
                       },
-                      "dwc:taxonomicStatus": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dwc:nomenclaturalCode": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dwc:vernacularName": {
+                      "dwc:subfamily": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -419,15 +467,6 @@
                           }
                         }
                       },
-                      "???:acceptedScientificName": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
                       "dwc:taxonID": {
                         "type": "text",
                         "fields": {
@@ -436,12 +475,8 @@
                             "ignore_above": 256
                           }
                         }
-                      }
-                    }
-                  },
-                  "citations": {
-                    "properties": {
-                      "???:citationRemarks": {
+                      },
+                      "dwc:taxonRank": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -450,7 +485,7 @@
                           }
                         }
                       },
-                      "dcterms:bibliographicCitation": {
+                      "dwc:taxonRemarks": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -459,7 +494,7 @@
                           }
                         }
                       },
-                      "???:citationPageNumber": {
+                      "dwc:taxonomicStatus": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -468,64 +503,7 @@
                           }
                         }
                       },
-                      "???:referenceType": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "???:referenceYear": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "???:referenceIri": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "???:isPeerReviewed": {
-                        "type": "boolean"
-                      },
-                      "dcterms:creator": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dcterms:date": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dcterms:title": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dcterms:type": {
+                      "dwc:vernacularName": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -535,6 +513,15 @@
                         }
                       }
                     }
+                  }
+                }
+              },
+              "dwc:institutionCode": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
                   }
                 }
               },
@@ -556,7 +543,25 @@
                   }
                 }
               },
+              "dwc:ownerInstitutionId": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
               "dwc:recordedBy": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "dwc:recordedById": {
                 "type": "text",
                 "fields": {
                   "keyword": {
@@ -567,7 +572,7 @@
               },
               "entityRelationships": {
                 "properties": {
-                  "entityRelationshipType": {
+                  "entityRelationshipCreatorId": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -576,7 +581,7 @@
                       }
                     }
                   },
-                  "objectEntityIri": {
+                  "entityRelationshipCreatorName": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -603,7 +608,7 @@
                       }
                     }
                   },
-                  "entityRelationshipCreatorName": {
+                  "entityRelationshipType": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -612,7 +617,7 @@
                       }
                     }
                   },
-                  "entityRelationshipCreatorId": {
+                  "objectEntityIri": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -642,288 +647,12 @@
                         "ignore_above": 256
                       }
                     }
-                  },
-                  "???:partOfLabel": {
-                    "type": "boolean"
-                  },
-                  "???:barcodeOrNfc": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "isIdPersistent": {
-                    "type": "boolean"
                   }
                 }
               },
               "occurrences": {
                 "properties": {
-                  "dwc:eventDate": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:occurrenceRemarks": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:organismQuantity": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:organismQuantityType": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:sex": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:lifeStage": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:reproductiveCondition": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:behavior": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:establishmentMeans": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:occurrenceStatus": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:pathway": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:degreeOfEstablishment": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:georeferenceVerificationStatus": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:informationWithheld": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:dataGeneralizations": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:recordedBy": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:recordedById": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "???:eventName": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:fieldNumber": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:year": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:month": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:day": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:habitat": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "???:protocolDescription": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:sampleSizeValue": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:sampleSizeUnit": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:samplingProtocol": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "???:eventEffort": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:fieldNotes": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "dwc:eventRemarks": {
+                  "???:collectorId": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -941,7 +670,25 @@
                       }
                     }
                   },
-                  "???:collectorId": {
+                  "???:eventEffort": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "???:eventName": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "???:protocolDescription": {
                     "type": "text",
                     "fields": {
                       "keyword": {
@@ -952,46 +699,7 @@
                   },
                   "assertions": {
                     "properties": {
-                      "???:assertionType": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "???:assertionMadeDate": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "???:assertionEffectiveDate": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "???:assertionValue": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "???:assertionValueNumeric": {
-                        "type": "float"
-                      },
-                      "???:assertionUnit": {
+                      "???:assertionByAgentId": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -1009,7 +717,16 @@
                           }
                         }
                       },
-                      "???:assertionByAgentId": {
+                      "???:assertionEffectiveDate": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
+                      "???:assertionMadeDate": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -1044,39 +761,285 @@
                             "ignore_above": 256
                           }
                         }
+                      },
+                      "???:assertionType": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
+                      "???:assertionUnit": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
+                      "???:assertionValue": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
+                      "???:assertionValueNumeric": {
+                        "type": "float"
+                      }
+                    }
+                  },
+                  "dwc:behavior": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:dataGeneralizations": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:day": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:degreeOfEstablishment": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:establishmentMeans": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:eventDate": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:eventRemarks": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:fieldNotes": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:fieldNumber": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:georeferenceVerificationStatus": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:habitat": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:informationWithheld": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:lifeStage": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:month": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:occurrenceRemarks": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:occurrenceStatus": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:organismQuantity": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:organismQuantityType": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:pathway": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:recordedBy": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:recordedById": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:reproductiveCondition": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:sampleSizeUnit": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:sampleSizeValue": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:samplingProtocol": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:sex": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
+                    }
+                  },
+                  "dwc:year": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
                       }
                     }
                   },
                   "location": {
                     "properties": {
                       "dwc:continent": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dwc:waterBody": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dwc:islandGroup": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dwc:island": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -1103,52 +1066,7 @@
                           }
                         }
                       },
-                      "dwc:municipality": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dwc:minimumElevationInMeters": {
-                        "type": "double"
-                      },
-                      "dwc:maximumElevationInMeters": {
-                        "type": "double"
-                      },
-                      "dwc:minimumDistanceAboveSurfaceInMeters": {
-                        "type": "double"
-                      },
-                      "dwc:maximumDistanceAboveSurfaceInMeters": {
-                        "type": "double"
-                      },
-                      "dwc:minimumDepthInMeters": {
-                        "type": "double"
-                      },
-                      "dwc:maximumDepthInMeters": {
-                        "type": "double"
-                      },
-                      "dwc:verticalDatum": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dwc:locationRemarks": {
-                        "type": "text",
-                        "fields": {
-                          "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
-                          }
-                        }
-                      },
-                      "dwc:locationAccordingTo": {
+                      "dwc:county": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -1166,7 +1084,16 @@
                           }
                         }
                       },
-                      "dwc:county": {
+                      "dwc:island": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
+                      "dwc:islandGroup": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -1184,7 +1111,70 @@
                           }
                         }
                       },
+                      "dwc:locationAccordingTo": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
+                      "dwc:locationRemarks": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
+                      "dwc:maximumDepthInMeters": {
+                        "type": "double"
+                      },
+                      "dwc:maximumDistanceAboveSurfaceInMeters": {
+                        "type": "double"
+                      },
+                      "dwc:maximumElevationInMeters": {
+                        "type": "double"
+                      },
+                      "dwc:minimumDepthInMeters": {
+                        "type": "double"
+                      },
+                      "dwc:minimumDistanceAboveSurfaceInMeters": {
+                        "type": "double"
+                      },
+                      "dwc:minimumElevationInMeters": {
+                        "type": "double"
+                      },
+                      "dwc:municipality": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
                       "dwc:stateProvince": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
+                      "dwc:verticalDatum": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
+                        }
+                      },
+                      "dwc:waterBody": {
                         "type": "text",
                         "fields": {
                           "keyword": {
@@ -1195,6 +1185,15 @@
                       },
                       "geologicalContext": {
                         "properties": {
+                          "dwc:bed": {
+                            "type": "text",
+                            "fields": {
+                              "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                              }
+                            }
+                          },
                           "dwc:earliestAgeOrLowestStage": {
                             "type": "text",
                             "fields": {
@@ -1232,6 +1231,33 @@
                             }
                           },
                           "dwc:earliestPeriodOrLowestSystem": {
+                            "type": "text",
+                            "fields": {
+                              "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                              }
+                            }
+                          },
+                          "dwc:formation": {
+                            "type": "text",
+                            "fields": {
+                              "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                              }
+                            }
+                          },
+                          "dwc:group": {
+                            "type": "text",
+                            "fields": {
+                              "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                              }
+                            }
+                          },
+                          "dwc:highestBiostratigraphicZone": {
                             "type": "text",
                             "fields": {
                               "keyword": {
@@ -1285,24 +1311,6 @@
                               }
                             }
                           },
-                          "dwc:lowestBiostratigraphicZone": {
-                            "type": "text",
-                            "fields": {
-                              "keyword": {
-                                "type": "keyword",
-                                "ignore_above": 256
-                              }
-                            }
-                          },
-                          "dwc:highestBiostratigraphicZone": {
-                            "type": "text",
-                            "fields": {
-                              "keyword": {
-                                "type": "keyword",
-                                "ignore_above": 256
-                              }
-                            }
-                          },
                           "dwc:lithostratigraphicTerms": {
                             "type": "text",
                             "fields": {
@@ -1312,16 +1320,7 @@
                               }
                             }
                           },
-                          "dwc:group": {
-                            "type": "text",
-                            "fields": {
-                              "keyword": {
-                                "type": "keyword",
-                                "ignore_above": 256
-                              }
-                            }
-                          },
-                          "dwc:formation": {
+                          "dwc:lowestBiostratigraphicZone": {
                             "type": "text",
                             "fields": {
                               "keyword": {
@@ -1338,8 +1337,12 @@
                                 "ignore_above": 256
                               }
                             }
-                          },
-                          "dwc:bed": {
+                          }
+                        }
+                      },
+                      "georeference": {
+                        "properties": {
+                          "???:preferredSpatialRepresentation": {
                             "type": "text",
                             "fields": {
                               "keyword": {
@@ -1347,36 +1350,20 @@
                                 "ignore_above": 256
                               }
                             }
-                          }
-                        }
-                      },
-                      "georeference": {
-                        "properties": {
+                          },
+                          "dwc:coordinatePrecision": {
+                            "type": "float"
+                          },
+                          "dwc:coordinateUncertaintyInMeters": {
+                            "type": "float"
+                          },
                           "dwc:decimalLatitude": {
                             "type": "float"
                           },
                           "dwc:decimalLongitude": {
                             "type": "float"
                           },
-                          "dwc:geodeticDatum": {
-                            "type": "text",
-                            "fields": {
-                              "keyword": {
-                                "type": "keyword",
-                                "ignore_above": 256
-                              }
-                            }
-                          },
-                          "dwc:coordinateUncertaintyInMeters": {
-                            "type": "float"
-                          },
-                          "dwc:coordinatePrecision": {
-                            "type": "float"
-                          },
-                          "dwc:pointRadiusSpatialFit": {
-                            "type": "float"
-                          },
-                          "dwc:footprintWkt": {
+                          "dwc:footprintSpatialFit": {
                             "type": "text",
                             "fields": {
                               "keyword": {
@@ -1394,7 +1381,7 @@
                               }
                             }
                           },
-                          "dwc:footprintSpatialFit": {
+                          "dwc:footprintWkt": {
                             "type": "text",
                             "fields": {
                               "keyword": {
@@ -1403,16 +1390,7 @@
                               }
                             }
                           },
-                          "dwc:georeferencedBy": {
-                            "type": "text",
-                            "fields": {
-                              "keyword": {
-                                "type": "keyword",
-                                "ignore_above": 256
-                              }
-                            }
-                          },
-                          "dwc:georeferencedDate": {
+                          "dwc:geodeticDatum": {
                             "type": "text",
                             "fields": {
                               "keyword": {
@@ -1439,15 +1417,6 @@
                               }
                             }
                           },
-                          "???:preferredSpatialRepresentation": {
-                            "type": "text",
-                            "fields": {
-                              "keyword": {
-                                "type": "keyword",
-                                "ignore_above": 256
-                              }
-                            }
-                          },
                           "dwc:georeferenceSources": {
                             "type": "text",
                             "fields": {
@@ -1456,12 +1425,36 @@
                                 "ignore_above": 256
                               }
                             }
+                          },
+                          "dwc:georeferencedBy": {
+                            "type": "text",
+                            "fields": {
+                              "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                              }
+                            }
+                          },
+                          "dwc:georeferencedDate": {
+                            "type": "text",
+                            "fields": {
+                              "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                              }
+                            }
+                          },
+                          "dwc:pointRadiusSpatialFit": {
+                            "type": "float"
                           }
                         }
                       }
                     }
                   }
                 }
+              },
+              "ods:hasMedia": {
+                "type": "boolean"
               },
               "ods:livingOrPreserved": {
                 "type": "text",
@@ -1472,7 +1465,10 @@
                   }
                 }
               },
-              "ods:physicalSpecimenId": {
+              "ods:markedAsType": {
+                "type": "boolean"
+              },
+              "ods:normalisedPhysicalSpecimenId": {
                 "type": "text",
                 "fields": {
                   "keyword": {
@@ -1481,7 +1477,7 @@
                   }
                 }
               },
-              "ods:normalisedPhysicalSpecimenId": {
+              "ods:physicalSpecimenId": {
                 "type": "text",
                 "fields": {
                   "keyword": {
@@ -1508,12 +1504,6 @@
                   }
                 }
               },
-              "ods:markedAsType": {
-                "type": "boolean"
-              },
-              "ods:hasMedia": {
-                "type": "boolean"
-              },
               "ods:specimenName": {
                 "type": "text",
                 "fields": {
@@ -1532,15 +1522,6 @@
                   }
                 }
               },
-              "ods:topicOrigin": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
               "ods:topicDomain": {
                 "type": "text",
                 "fields": {
@@ -1550,79 +1531,7 @@
                   }
                 }
               },
-              "dcterms:license": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dcterms:preparations": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dcterms:disposition": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dwc:institutionCode": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dwc:recordedById": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dwc:ownerInstitutionId": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dwc:datasetName": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dcterms:accessRights": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "dcterms:rightsHolder": {
+              "ods:topicOrigin": {
                 "type": "text",
                 "fields": {
                   "keyword": {
@@ -1632,9 +1541,6 @@
                 }
               }
             }
-          },
-          "ods:originalAttributes": {
-            "type": "flattened"
           },
           "ods:normalisedPhysicalSpecimenId": {
             "type": "text",
@@ -1644,6 +1550,9 @@
                 "ignore_above": 256
               }
             }
+          },
+          "ods:originalAttributes": {
+            "type": "flattened"
           },
           "ods:type": {
             "type": "text",

--- a/shared-resources/templates/karpenter.yaml
+++ b/shared-resources/templates/karpenter.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: karpenter-argocd
+  namespace: argocd
+spec:
+  project: default
+  source:
+    chart: karpenter
+    repoURL: public.ecr.aws/karpenter
+    targetRevision: 0.35.2
+    helm:
+      releaseName: karpenter
+      values: |
+        serviceAccount:
+          annotations:
+            eks.amazonaws.com/role-arn: arn:aws:iam::824841205322:role/KarpenterControllerRole-dissco-k8s-test
+        settings:
+          clusterName: dissco-k8s-test
+        dnsPolicy: ClusterFirst
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: karpenter

--- a/test/authorisation.yaml
+++ b/test/authorisation.yaml
@@ -10,6 +10,11 @@ data:
       - system:nodes
       rolearn: arn:aws:iam::824841205322:role/managed_m5-eks-node-group-20230823064429571400000002
       username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::824841205322:role/KarpenterNodeRole-dissco-k8s-test
+      username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - groups:
       - system:masters

--- a/test/karpenter/nodegroup.yaml
+++ b/test/karpenter/nodegroup.yaml
@@ -1,0 +1,44 @@
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
+      nodeClassRef:
+        name: default
+  limits:
+    cpu: 1000
+  disruption:
+    consolidationPolicy: WhenUnderutilized
+    expireAfter: 720h # 30 * 24h = 720h
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  amiFamily: AL2 # Amazon Linux 2
+  role: "KarpenterNodeRole-dissco-k8s-test"
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "dissco-k8s-test"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "dissco-k8s-test"

--- a/test/nu-search/nu-search-deployment.yaml
+++ b/test/nu-search/nu-search-deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dissco-nu-search-deployment
+  labels:
+    app: dissco-nu-search-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dissco-nu-search-deployment
+  template:
+    metadata:
+      labels:
+        app: dissco-nu-search-deployment
+    spec:
+      containers:
+        - name: dissco-nu-search-deployment
+          image: public.ecr.aws/dissco/dissco-nusearch-service
+          imagePullPolicy: Always
+          env:
+            - name: kafka.publisher.host
+              value: kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+            - name: kafka.consumer.host
+              value: kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+            - name: kafka.consumer.topic
+              value: col
+            - name: indexing.col-password
+              valueFrom:
+                secretKeyRef:
+                  name: aws-secrets
+                  key: indexing-col-password
+            - name: indexing.col-username
+              value: sam_leeflang
+            - name: indexing.col-dataset
+              value: "286246"
+            - name: indexing.index-location
+              value: /index-files/index
+            - name: indexing.index-at-startup
+              value: "true"
+            - name: indexing.delete-index
+              value: "true"
+            - name: indexing.temp-coldp-location
+              value: /index-files/col-temp.zip
+            - name: JAVA_TOOL_OPTIONS
+              value: -XX:MaxRAMPercentage=85
+          resources:
+            requests:
+              memory: "6Gi"
+              cpu: "500m"
+            limits:
+              memory: "6Gi"
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - mountPath: /index-files
+              name: temp-volume
+      volumes:
+        - name: temp-volume
+          emptyDir: { }

--- a/test/nu-search/nu-search-topic.yaml
+++ b/test/nu-search/nu-search-topic.yaml
@@ -1,0 +1,13 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: col
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka-cluster
+spec:
+  partitions: 5
+  replicas: 3
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824

--- a/test/secret-manager/aws-secrets.yaml
+++ b/test/secret-manager/aws-secrets.yaml
@@ -17,6 +17,8 @@ spec:
           key: mongodb-connection
         - objectName: handle-endpoint-token
           key: handle-endpoint-token
+        - objectName: indexing-col-password
+          key: indexing-col-password
   parameters:
     objects: |
       - objectName: "arn:aws:secretsmanager:eu-west-2:824841205322:secret:dissco-test-secrets-CkrWsm"
@@ -29,3 +31,5 @@ spec:
               objectAlias: "mongodb-connection"
             - path: "handle_endpoint_token"
               objectAlias: "handle-endpoint-token"
+            - path: "indexing_col_password"
+              objectAlias: "indexing-col-password"


### PR DESCRIPTION
Couple things:
- Add karpenter helm chart to cluster. Got one issue as it is a shared resource but now it contains a specific value for the test env. Created a task to fix this: https://naturalis.atlassian.net/browse/DD-1045
- Add current version (with major ram needs) to dev cluster
- Some minor change for acceptance
- Sync with latest version of elastic index