### PR TITLE
Add translator-services namespace

### DIFF
--- a/test/nu-search/nu-search-deployment.yaml
+++ b/test/nu-search/nu-search-deployment.yaml
@@ -62,13 +62,15 @@ spec:
               value: /index-files/col-temp.zip
             - name: JAVA_TOOL_OPTIONS
               value: -XX:MaxRAMPercentage=85
+            - name: logging.level.root
+              value: INFO
           resources:
             requests:
               memory: "2Gi"
-              cpu: "500m"
+              cpu: "1500m"
             limits:
               memory: "2Gi"
-              cpu: "500m"
+              cpu: "1500m"
               ephemeral-storage: "10Gi"
           securityContext:
             runAsNonRoot: true

--- a/test/orchestration-backend/orchestration-backend-roles.yaml
+++ b/test/orchestration-backend/orchestration-backend-roles.yaml
@@ -32,3 +32,30 @@ roleRef:
   kind: Role
   name: orchestration-backend-role
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: translator-services
+  name: orchestration-backend-translator-role
+rules:
+  - apiGroups: ["batch"] # "" indicates the core API group
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [ "batch" ] # "" indicates the core API group
+    resources: [ "cronjobs" ]
+    verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: translator-admin-role
+  namespace: translator-services
+subjects:
+  - kind: ServiceAccount
+    name: dissco-orchestration-backend-sa
+    namespace: default
+roleRef:
+  kind: Role
+  name: orchestration-backend-translator-role
+  apiGroup: rbac.authorization.k8s.io

--- a/test/translator-services/db-secrets.yaml
+++ b/test/translator-services/db-secrets.yaml
@@ -1,0 +1,23 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: db-secrets
+  namespace: translator-services
+spec:
+  provider: aws
+  secretObjects:
+    - secretName: db-secrets
+      type: Opaque
+      data:
+        - objectName: db-username
+          key: db-username
+        - objectName: db-password
+          key: db-password
+  parameters:
+    objects: |
+      - objectName: "arn:aws:secretsmanager:eu-west-2:824841205322:secret:rds!db-f6cbaaf0-79c4-4385-9302-83c467caf3a1-2nERsy"
+        jmesPath:
+            - path: "username"
+              objectAlias: "db-username"
+            - path: "password"
+              objectAlias: "db-password"

--- a/test/translator-services/translator-namespace.yaml
+++ b/test/translator-services/translator-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: translator-services

--- a/test/translator-services/translator-service-account.yaml
+++ b/test/translator-services/translator-service-account.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: translator-secret-manager
+  namespace: translator-services
+  annotations: {
+    eks.amazonaws.com/role-arn: "arn:aws:iam::824841205322:role/secret-manager"
+  }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-manager
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["secrets"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: read-secrets-global
+subjects:
+  - kind: ServiceAccount
+    name: translator-secret-manager
+    namespace: translator-services
+roleRef:
+  kind: ClusterRole
+  name: secret-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- nu-search needed some more juice
- added orchestration-backend roles so that it can create job and cronjob's in translator-services namespace
- added translator-service namespace
- added accounts and secrets so that pods in translator-services namespace can get secrets