### PR TITLE
Feature/alive ready checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ ArgoCD monitors the `main` branch of the GitHub repo.
 When new changes are made it will automatically recognise that kubernetes is no longer in sync with the files in the repo.
 It can then automatically synchronise the cluster with the changed kubernetes files.
 There is also an option to leave the actual syncrhonisation a manual action.
+
+## Kube Green
+The installation of kube-green is still  manual.
+Follow the steps on this website: https://kube-green.dev/docs/install/

--- a/test/annotation/annotation-processor-kafka.yaml
+++ b/test/annotation/annotation-processor-kafka.yaml
@@ -19,6 +19,7 @@ spec:
         co.elastic.logs/multiline.negate: "false"
         co.elastic.logs/multiline.match: after
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: dissco-core-annotation-processing-kafka
           image: public.ecr.aws/dissco/dissco-core-annotation-processing-service
@@ -89,6 +90,19 @@ spec:
               cpu: "200m"
             limits:
               memory: "500Mi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 5
+            failureThreshold: 2
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/test/annotation/annotation-processor-web.yaml
+++ b/test/annotation/annotation-processor-web.yaml
@@ -19,6 +19,7 @@ spec:
         co.elastic.logs/multiline.negate: "false"
         co.elastic.logs/multiline.match: after
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: dissco-core-annotation-processing-web
           image: public.ecr.aws/dissco/dissco-core-annotation-processing-service
@@ -91,6 +92,19 @@ spec:
               cpu: "200m"
             limits:
               memory: "500Mi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 5
+            failureThreshold: 2
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/test/backend/backend-deployment.yaml
+++ b/test/backend/backend-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         co.elastic.logs/multiline.match: after
     spec:
       serviceAccountName: secret-manager
+      automountServiceAccountToken: true
       containers:
         - name: dissco-backend
           image: public.ecr.aws/dissco/dissco-core-backend
@@ -54,8 +55,6 @@ spec:
                 secretKeyRef:
                   name: aws-secrets
                   key: elastic-password
-            - name: management.health.elasticsearch.enabled
-              value: "false"
             - name: springdoc.api-docs.path
               value: /api/v3/api-docs
             - name: springdoc.swagger-ui.path
@@ -104,6 +103,20 @@ spec:
               cpu: "200m"
             limits:
               memory: "500Mi"
+              cpu: "500m"
+              ephemeral-storage: "32Mi"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 60
+            failureThreshold: 2
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/test/digital-media-object/digital-media-object-processor-kafka.yaml
+++ b/test/digital-media-object/digital-media-object-processor-kafka.yaml
@@ -19,6 +19,7 @@ spec:
         co.elastic.logs/multiline.negate: "false"
         co.elastic.logs/multiline.match: after
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: dissco-digital-media-object-processor-kafka
           image: public.ecr.aws/dissco/dissco-core-digital-media-object-processor
@@ -87,6 +88,19 @@ spec:
               cpu: "500m"
             limits:
               memory: "1Gi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 15
+            failureThreshold: 2
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/test/digital-media-object/digital-media-object-processor-web.yaml
+++ b/test/digital-media-object/digital-media-object-processor-web.yaml
@@ -19,6 +19,7 @@ spec:
         co.elastic.logs/multiline.negate: "false"
         co.elastic.logs/multiline.match: after
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: dissco-digital-media-object-processor-web
           image: public.ecr.aws/dissco/dissco-core-digital-media-object-processor
@@ -87,6 +88,19 @@ spec:
               cpu: "200m"
             limits:
               memory: "500Mi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 15
+            failureThreshold: 2
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/test/digital-specimen/digital-specimen-processor-kafka.yaml
+++ b/test/digital-specimen/digital-specimen-processor-kafka.yaml
@@ -19,6 +19,7 @@ spec:
         co.elastic.logs/multiline.negate: "false"
         co.elastic.logs/multiline.match: after
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: dissco-digital-specimen-processor-kafka
           image: public.ecr.aws/dissco/dissco-core-digital-specimen-processor
@@ -89,6 +90,19 @@ spec:
               cpu: "500m"
             limits:
               memory: "1Gi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 15
+            failureThreshold: 2
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/test/digital-specimen/digital-specimen-processor-web.yaml
+++ b/test/digital-specimen/digital-specimen-processor-web.yaml
@@ -19,6 +19,7 @@ spec:
         co.elastic.logs/multiline.negate: "false"
         co.elastic.logs/multiline.match: after
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: dissco-digital-specimen-processor-web
           image: public.ecr.aws/dissco/dissco-core-digital-specimen-processor
@@ -87,6 +88,19 @@ spec:
               cpu: "200m"
             limits:
               memory: "500Mi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 15
+            failureThreshold: 2
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/test/frontend/frontend-deployment.yaml
+++ b/test/frontend/frontend-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: disscover
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: disscover
           image: public.ecr.aws/dissco/disscover:latest
@@ -25,4 +26,5 @@ spec:
               cpu: "100m"
             limits:
               memory: "100Mi"
+              cpu: "200m"
       restartPolicy: Always

--- a/test/handle-manager/handle-manager-deployment.yaml
+++ b/test/handle-manager/handle-manager-deployment.yaml
@@ -19,12 +19,14 @@ spec:
         co.elastic.logs/multiline.negate: "false"
         co.elastic.logs/multiline.match: after
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: dissco-handle-manager
           image: public.ecr.aws/dissco/handle-manager
           imagePullPolicy: Always
           ports:
             - containerPort: 80
+            - containerPort: 8080
           env:
             - name: spring.security.oauth2.resourceserver.jwt.issuer-uri
               value: https://login-demo.dissco.eu/auth/realms/dissco
@@ -54,6 +56,25 @@ spec:
                   key: db-password
             - name: application.prefix
               value: TEST
+          resources:
+            requests:
+              memory: "500Mi"
+              cpu: "200m"
+            limits:
+              memory: "500Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 45
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 45
+            failureThreshold: 2
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/test/kube-green/kube-green-dissco-weekend.yaml
+++ b/test/kube-green/kube-green-dissco-weekend.yaml
@@ -1,0 +1,23 @@
+apiVersion: kube-green.com/v1alpha1
+kind: SleepInfo
+metadata:
+  name: dissco-sleep-weekend
+  namespace: default
+spec:
+  weekdays: "0,6"
+  sleepAt: "*:*"
+  timeZone: "Europe/Amsterdam"
+  suspendCronJobs: true
+  excludeRef:
+    - apiVersion: "apps/v1"
+      kind: Deployment
+      name: traefik
+    - apiVersion: "apps/v1"
+      kind: Deployment
+      name: dissco-backend-deployment
+    - apiVersion: "apps/v1"
+      kind: Deployment
+      name: dissco-schemas-deployment
+    - apiVersion: "apps/v1"
+      kind: Deployment
+      name: disscover

--- a/test/kube-green/kube-green-dissco-working-hours.yaml
+++ b/test/kube-green/kube-green-dissco-working-hours.yaml
@@ -1,0 +1,24 @@
+apiVersion: kube-green.com/v1alpha1
+kind: SleepInfo
+metadata:
+  name: dissco-sleep-working-hours
+  namespace: default
+spec:
+  weekdays: "1-5"
+  sleepAt: "18:00"
+  wakeUpAt: "07:00"
+  timeZone: "Europe/Amsterdam"
+  suspendCronJobs: true
+  excludeRef:
+    - apiVersion: "apps/v1"
+      kind: Deployment
+      name: traefik
+    - apiVersion: "apps/v1"
+      kind: Deployment
+      name: dissco-backend-deployment
+    - apiVersion: "apps/v1"
+      kind: Deployment
+      name: dissco-schemas-deployment
+    - apiVersion: "apps/v1"
+      kind: Deployment
+      name: disscover

--- a/test/nu-search/nu-search-deployment.yaml
+++ b/test/nu-search/nu-search-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         co.elastic.logs/multiline.negate: "false"
         co.elastic.logs/multiline.match: after
     spec:
+      automountServiceAccountToken: true
       serviceAccountName: nu-search-sa
       containers:
         - name: dissco-nu-search-deployment
@@ -72,6 +73,18 @@ spec:
               memory: "2Gi"
               cpu: "1500m"
               ephemeral-storage: "10Gi"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 30
+            failureThreshold: 2
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/test/orchestration-backend/orchestration-backend.yaml
+++ b/test/orchestration-backend/orchestration-backend.yaml
@@ -15,6 +15,7 @@ spec:
         app: dissco-orchestration-backend
         language: java
     spec:
+      automountServiceAccountToken: true
       serviceAccountName: dissco-orchestration-backend-sa
       containers:
         - name: dissco-orchestration-backend
@@ -66,6 +67,20 @@ spec:
               cpu: "200m"
             limits:
               memory: "500Mi"
+              cpu: "1000m"
+              ephemeral-storage: "1Gi"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 5
+            failureThreshold: 2
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/test/orchestration-frontend/orchestration-frontend.yaml
+++ b/test/orchestration-frontend/orchestration-frontend.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: dissco-orchestration-frontend
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: dissco-orchestration-frontend
           image: public.ecr.aws/dissco/orchestration-frontend:latest
@@ -25,4 +26,5 @@ spec:
               cpu: "100m"
             limits:
               memory: "100Mi"
+              cpu: "200m"
       restartPolicy: Always

--- a/test/provenance/provenance-deployment.yaml
+++ b/test/provenance/provenance-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         co.elastic.logs/multiline.negate: "false"
         co.elastic.logs/multiline.match: after
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: dissco-provenance-service
           image: public.ecr.aws/dissco/dissco-core-provenance-service
@@ -51,6 +52,19 @@ spec:
               cpu: "200m"
             limits:
               memory: "500Mi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 5
+            failureThreshold: 2
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/test/secret-manager/service-account.yaml
+++ b/test/secret-manager/service-account.yaml
@@ -14,7 +14,7 @@ metadata:
 rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["secrets"]
-    verbs: ["*"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/traefik/deployment.yaml
+++ b/test/traefik/deployment.yaml
@@ -110,6 +110,7 @@ spec:
             limits:
               memory: "250Mi"
               cpu: "200m"
+              ephemeral-storage: "1Gi"
           args:
             - --accesslog
             - --entrypoints.web.Address=:80

--- a/test/translator-services/translator-service-account.yaml
+++ b/test/translator-services/translator-service-account.yaml
@@ -14,7 +14,7 @@ metadata:
 rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["secrets"]
-    verbs: ["*"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
- Alive and health checks for all applications. Multiple applications were updated so they would run a webserver for the checks
- Sonar now has comments for Kubernetes files. It is still experimental and doesn't always work great but took over what is applicable.
- Added kube-green to test run it. Trying to keep the dev.dissco.tech alive but put the rest in sleep mode. Might need to do this for Kafka and other services/namespaces too.