### PR TITLE
increase readiness check delay

### DIFF
--- a/acceptance/digital-media-object/digital-media-object-processor-web.yaml
+++ b/acceptance/digital-media-object/digital-media-object-processor-web.yaml
@@ -93,13 +93,13 @@ spec:
             httpGet:
               path: /actuator/health/liveness
               port: 8080
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
-            initialDelaySeconds: 45
+            initialDelaySeconds: 60
             failureThreshold: 2
           securityContext:
             runAsNonRoot: true

--- a/test/annotation/annotation-processor-kafka.yaml
+++ b/test/annotation/annotation-processor-kafka.yaml
@@ -93,13 +93,13 @@ spec:
             httpGet:
               path: /actuator/health/liveness
               port: 8080
-            initialDelaySeconds: 3
+            initialDelaySeconds: 60
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
-            initialDelaySeconds: 5
+            initialDelaySeconds: 60
             failureThreshold: 2
           securityContext:
             runAsNonRoot: true

--- a/test/annotation/annotation-processor-web.yaml
+++ b/test/annotation/annotation-processor-web.yaml
@@ -95,13 +95,13 @@ spec:
             httpGet:
               path: /actuator/health/liveness
               port: 8080
-            initialDelaySeconds: 3
+            initialDelaySeconds: 60
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
-            initialDelaySeconds: 5
+            initialDelaySeconds: 60
             failureThreshold: 2
           securityContext:
             runAsNonRoot: true

--- a/test/digital-media-object/digital-media-object-processor-kafka.yaml
+++ b/test/digital-media-object/digital-media-object-processor-kafka.yaml
@@ -93,13 +93,13 @@ spec:
             httpGet:
               path: /actuator/health/liveness
               port: 8080
-            initialDelaySeconds: 15
+            initialDelaySeconds: 60
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
-            initialDelaySeconds: 15
+            initialDelaySeconds: 60
             failureThreshold: 2
           securityContext:
             runAsNonRoot: true

--- a/test/digital-media-object/digital-media-object-processor-web.yaml
+++ b/test/digital-media-object/digital-media-object-processor-web.yaml
@@ -93,13 +93,13 @@ spec:
             httpGet:
               path: /actuator/health/liveness
               port: 8080
-            initialDelaySeconds: 15
+            initialDelaySeconds: 60
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
-            initialDelaySeconds: 15
+            initialDelaySeconds: 60
             failureThreshold: 2
           securityContext:
             runAsNonRoot: true

--- a/test/digital-specimen/digital-specimen-processor-kafka.yaml
+++ b/test/digital-specimen/digital-specimen-processor-kafka.yaml
@@ -95,13 +95,13 @@ spec:
             httpGet:
               path: /actuator/health/liveness
               port: 8080
-            initialDelaySeconds: 15
+            initialDelaySeconds: 60
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
-            initialDelaySeconds: 15
+            initialDelaySeconds: 60
             failureThreshold: 2
           securityContext:
             runAsNonRoot: true

--- a/test/orchestration-backend/orchestration-backend.yaml
+++ b/test/orchestration-backend/orchestration-backend.yaml
@@ -19,7 +19,7 @@ spec:
         co.elastic.logs/multiline.negate: "false"
         co.elastic.logs/multiline.match: after
     spec:
-      automountServiceAccountToken: true
+      automountServiceAccountToken: false
       serviceAccountName: dissco-orchestration-backend-sa
       containers:
         - name: dissco-orchestration-backend
@@ -77,13 +77,13 @@ spec:
             httpGet:
               path: /actuator/health/liveness
               port: 8080
-            initialDelaySeconds: 3
+            initialDelaySeconds: 60
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
-            initialDelaySeconds: 5
+            initialDelaySeconds: 60
             failureThreshold: 2
           securityContext:
             runAsNonRoot: true

--- a/test/provenance/provenance-deployment.yaml
+++ b/test/provenance/provenance-deployment.yaml
@@ -57,13 +57,13 @@ spec:
             httpGet:
               path: /actuator/health/liveness
               port: 8080
-            initialDelaySeconds: 3
+            initialDelaySeconds: 60
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
-            initialDelaySeconds: 5
+            initialDelaySeconds: 60
             failureThreshold: 2
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
Readiness/liveness check was occurring before the application was finished starting up, causing crashes in these pods. Setting initial time delay to 60 seconds fixes the issue. May be possible to reduce this to 30 seconds if we really want to.

These are already deployed. 