### PR TITLE
cors for orchestration and backend service

### DIFF
--- a/test/backend/backend-route.yaml
+++ b/test/backend/backend-route.yaml
@@ -24,3 +24,20 @@ spec:
         - name: dissco-backend-service
           namespace: default
           port: 8080
+      middlewares:
+        - name: dissco-backend-cors-headers
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: dissco-backend-cors-headers
+spec:
+  headers:
+    accessControlAllowMethods:
+      - "GET"
+    accessControlAllowHeaders:
+      - "*"
+    accessControlAllowOriginListRegex:
+      - "https:\\/\\/dev-orchestration\\.dissco\\.tech\\/.+"
+    accessControlMaxAge: 100
+    addVaryHeader: true

--- a/test/orchestration-backend/orchestration-backend-route.yaml
+++ b/test/orchestration-backend/orchestration-backend-route.yaml
@@ -26,6 +26,7 @@ spec:
           port: 8080
       middlewares:
         - name: dissco-orchestration-backend-stripprefix
+        - name: dissco-orchestration-cors-headers
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
@@ -36,3 +37,18 @@ spec:
     prefixes:
       - /api/v1
     forceSlash: false
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: dissco-orchestration-cors-headers
+spec:
+  headers:
+    accessControlAllowMethods:
+      - "GET"
+    accessControlAllowHeaders:
+      - "*"
+    accessControlAllowOriginList:
+      - "*"
+    accessControlMaxAge: 100
+    addVaryHeader: true

--- a/test/orchestration-backend/orchestration-backend-route.yaml
+++ b/test/orchestration-backend/orchestration-backend-route.yaml
@@ -48,7 +48,7 @@ spec:
       - "GET"
     accessControlAllowHeaders:
       - "*"
-    accessControlAllowOriginList:
-      - "*"
+    accessControlAllowOriginListRegex:
+      - "https:\\/\\/dev\\.dissco\\.tech\\/.+"
     accessControlMaxAge: 100
     addVaryHeader: true


### PR DESCRIPTION
https://naturalis.atlassian.net/browse/DD-1142?atlOrigin=eyJpIjoiZDY2ZWY1YzYwZTBjNDhjY2I4OGVkNmFkZWJmMjkzY2IiLCJwIjoiaiJ9

"Check CORS rules in the core and orchestration back-end to make sure DiSSCover and orchestration are allowed to access and use each other’s resources."

Regex allows any origin from dev env or orchestration to access each other. Could also replace with a wildcard if we want it to be open. 

https://doc.traefik.io/traefik/middlewares/http/headers/#accesscontrolalloworiginlistregex