### PR TITLE
split ses and s3 secrets

### DIFF
--- a/test/data-export-job/aws-secrets.yaml
+++ b/test/data-export-job/aws-secrets.yaml
@@ -2,7 +2,7 @@ apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: aws-secrets
-  namespace: export-s3-job
+  namespace: data-export-job
 spec:
   provider: aws
   secretObjects:

--- a/test/data-export-job/aws-secrets.yaml
+++ b/test/data-export-job/aws-secrets.yaml
@@ -2,7 +2,7 @@ apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: aws-secrets
-  namespace: data-export-job
+  namespace: export-s3-job
 spec:
   provider: aws
   secretObjects:
@@ -13,10 +13,10 @@ spec:
           key: elastic-username
         - objectName: elastic-password
           key: elastic-password
-        - objectName: data-export-access-key
-          key: data--access-key
-        - objectName: data-export-access-key-secret
-          key: data-export-access-key-secret
+        - objectName: export-s3-access-key
+          key: export-s3-access-key
+        - objectName: export-s3-access-key-secret
+          key: export-s3-access-key-secret
   parameters:
     objects: |
       - objectName: "arn:aws:secretsmanager:eu-west-2:824841205322:secret:dissco-test-secrets-CkrWsm"
@@ -25,7 +25,7 @@ spec:
               objectAlias: "elastic-username"
             - path: "elastic_password"
               objectAlias: "elastic-password"
-            - path: "data_export_access_key"
-              objectAlias: data-export-access-key
-            - path: "data_export_access_key"
-              objectAlias: data-export-access-key-secret
+            - path: "export_s3_access_key"
+              objectAlias: export-s3-access-key
+            - path: "export_s3_access_key"
+              objectAlias: export-s3-access-key-secret

--- a/test/data-exporter-backend/data-exporter-backend.yaml
+++ b/test/data-exporter-backend/data-exporter-backend.yaml
@@ -43,12 +43,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: aws-secrets
-                  key: data-export-access-key
+                  key: ses-access-key
             - name: aws.secret-access-key
               valueFrom:
                 secretKeyRef:
                   name: aws-secrets
-                  key: data-export-access-key-secret
+                  key: ses-key-secret
           resources:
             requests:
               memory: "500Mi"

--- a/test/secret-manager/aws-secrets.yaml
+++ b/test/secret-manager/aws-secrets.yaml
@@ -23,10 +23,10 @@ spec:
           key: col-bucket-access-key-id
         - objectName: col-bucket-access-key-secret
           key: col-bucket-access-key-secret
-        - objectName: data-export-access-key
-          key: data-export-access-key
-        - objectName: data-export-access-key-secret
-          key: data-export-access-key-secret
+        - objectName: ses-access-key
+          key: ses-access-key
+        - objectName: ses-access-key-secret
+          key: ses-access-key-secret
   parameters:
     objects: |
       - objectName: "arn:aws:secretsmanager:eu-west-2:824841205322:secret:dissco-test-secrets-CkrWsm"
@@ -45,7 +45,7 @@ spec:
               objectAlias: "col-bucket-access-key-id"
             - path: "col_bucket_access_key_secret"
               objectAlias: "col-bucket-access-key-secret"
-            - path: "data_export_access_key"
-              objectAlias: "data-export-access-key"
-            - path: "data_export_access_key_secret"
-              objectAlias: "data-export-access-key-secret"
+            - path: "ses_access_key"
+              objectAlias: "ses-access-key"
+            - path: "ses_access_key_secret"
+              objectAlias: "ses-access-key-secret"


### PR DESCRIPTION
- ses secret is needed for data exporter backend
- s3 secret is needed for export job (user is managed by tf)