### PR TITLE
Feature/otel fixes

### DIFF
--- a/test-helm-resources/templates/kube-state-metrics-argocd.yaml
+++ b/test-helm-resources/templates/kube-state-metrics-argocd.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-state-metrics-argocd
+  namespace: argocd
+spec:
+  project: default
+  source:
+    chart: kube-state-metrics
+    repoURL: https://prometheus-community.github.io/helm-charts
+    targetRevision: 5.27.0
+    helm:
+      releaseName: kube-state-metrics
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: otel
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/test-helm-resources/templates/prometheus-node-exporter.yaml
+++ b/test-helm-resources/templates/prometheus-node-exporter.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prometheus-node-exporter-argocd
+  namespace: argocd
+spec:
+  project: default
+  source:
+    chart: prometheus-node-exporter
+    repoURL: https://prometheus-community.github.io/helm-charts
+    targetRevision: 4.42.0
+    helm:
+      releaseName: prometheus-node-exporter
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: otel
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/test/open-telemetry/otel-daemonset-collector.yaml
+++ b/test/open-telemetry/otel-daemonset-collector.yaml
@@ -74,12 +74,13 @@ spec:
             {
               "context": "datapoint",
               "statements": [
-                'set(attributes["deployment_environment"], "test-agent")',
+                'set(attributes["deployment_environment"], "test")',
                 'set(attributes["service_namespace"], "naturalis.bii.dissco")',
                 'set(attributes["service_name"], "dissco-node")',
                 'set(attributes["service_owner"], "soulaine.theocharides@naturalis.nl")',
                 'set(attributes["service_team"], "dissco")',
-                'set(attributes["node_name"], "${NODE_NAME}")'
+                'set(attributes["node_name"], "${NODE_NAME}")',
+                'set(attributes["cluster"], "${CLUSTER_NAME}")''
               ]
             }
           ]

--- a/test/open-telemetry/otel-daemonset-collector.yaml
+++ b/test/open-telemetry/otel-daemonset-collector.yaml
@@ -21,15 +21,119 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: CLUSTER_NAME
+      value: "test-cluster"
   config:
     {
       "connectors": { },
       "receivers": {
-        "kubeletstats": {
-          "collection_interval": "10s",
-          "auth_type": "serviceAccount",
-          "endpoint": "${NODE_NAME}:10250",
-          "insecure_skip_verify": true
+        "filelog": {
+          "include": [
+            "/var/log/pods/*/*/*.log"
+          ],
+          "start_at": "beginning",
+          "include_file_path": true,
+          "include_file_name": false,
+          "operators": [
+            # Find out which format is used by kubernetes
+            {
+              "type": "router",
+              "id": "get-format",
+              "routes": [
+                {
+                  "output": "parser-docker",
+                  "expr": "body matches \"^\\\\{\""
+                },
+                {
+                  "output": "parser-crio",
+                  "expr": "body matches \"^[^ Z]+ \""
+                },
+                {
+                  "output": "parser-containerd",
+                  "expr": "body matches \"^[^ Z]+Z\""
+                }
+              ]
+            },
+            # Parse CRI-O format
+            {
+              "type": "regex_parser",
+              "id": "parser-crio",
+              "regex": "^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$",
+              "output": "extract_metadata_from_filepath",
+              "timestamp": {
+                "parse_from": "attributes.time",
+                "layout_type": "gotime",
+                "layout": "2006-01-02T15:04:05.999999999Z07:00"
+              }
+            },
+            # Parse CRI-Containerd format
+            {
+              "type": "regex_parser",
+              "id": "parser-containerd",
+              "regex": "^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$",
+              "output": "extract_metadata_from_filepath",
+              "timestamp": {
+                "parse_from": "attributes.time",
+                "layout": "%Y-%m-%dT%H:%M:%S.%LZ"
+              }
+            },
+            # Parse Docker format
+            {
+              "type": "json_parser",
+              "id": "parser-docker",
+              "output": "extract_metadata_from_filepath",
+              "timestamp": {
+                "parse_from": "attributes.time",
+                "layout": "%Y-%m-%dT%H:%M:%S.%LZ"
+              }
+            },
+            # Extract metadata from file path
+            {
+              "type": "regex_parser",
+              "id": "extract_metadata_from_filepath",
+              "regex": "^.*\\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\\-]{16,36})\\/(?P<container_name>[^\\._]+)\\/(?P<restart_count>\\d+)\\.log$",
+              "parse_from": "attributes[\"log.file.path\"]",
+              "cache": {
+                "size": 128
+              }
+            },
+            # Rename attributes
+            {
+              "type": "move",
+              "from": "attributes[\"log.file.path\"]",
+              "to": "resource[\"filename\"]"
+            },
+            {
+              "type": "move",
+              "from": "attributes.container_name",
+              "to": "resource[\"container\"]"
+            },
+            {
+              "type": "move",
+              "from": "attributes.namespace",
+              "to": "resource[\"namespace\"]"
+            },
+            {
+              "type": "move",
+              "from": "attributes.pod_name",
+              "to": "resource[\"pod\"]"
+            },
+            {
+              "type": "add",
+              "field": "resource[\"cluster\"]",
+              "value": "${CLUSTER_NAME}"
+            },
+            {
+              "type": "add",
+              "field": "resource[\"service.namespace\"]",
+              "value": "naturalis.bii.dissco"
+            },
+            {
+              "type": "move",
+              "from": "attributes.log",
+              "to": "body"
+            }
+          ]
         }
       },
       "processors": {
@@ -38,36 +142,6 @@ spec:
           "check_interval": "5s",
           "limit_percentage": 80,
           "spike_limit_percentage": 25
-        },
-        "k8sattributes": {
-          "filter": {
-            "node_from_env_var": "${NODE_NAME}"
-          },
-          "pod_association": [
-            {
-              "sources": [
-                {
-                  "from": "resource_attribute",
-                  "name": "k8s.pod.ip"
-                }
-              ]
-            },
-            {
-              "sources": [
-                {
-                  "from": "resource_attribute",
-                  "name": "k8s.pod.uid"
-                }
-              ]
-            },
-            {
-              "sources": [
-                {
-                  "from": "connection"
-                }
-              ]
-            }
-          ]
         },
         "transform/host": {
           "metric_statements": [
@@ -80,7 +154,7 @@ spec:
                 'set(attributes["service_owner"], "soulaine.theocharides@naturalis.nl")',
                 'set(attributes["service_team"], "dissco")',
                 'set(attributes["node_name"], "${NODE_NAME}")',
-                'set(attributes["cluster"], "${CLUSTER_NAME}")''
+                'set(attributes["cluster"], "${CLUSTER_NAME}")'
               ]
             }
           ]
@@ -101,39 +175,43 @@ spec:
         }
       },
       "exporters": {
-        "otlp/metrics": {
-          "endpoint": "https://metrics.gateway.analytics.naturalis.io:443",
+        "otlp/logs": {
+          "endpoint": "https://logs.gateway.analytics.naturalis.io:443",
           "auth": {
             "authenticator": "oauth2client/client"
           }
-        }
+        },
       },
       "service": {
         "extensions": [
           "oauth2client/client",
           "health_check"
         ],
-        "pipelines": {
-          "metrics": {
-            "receivers": [
-              "kubeletstats"
-            ],
-            "processors": [
-              "batch",
-              "k8sattributes",
-              "memory_limiter",
-              "transform/host"
-            ],
-            "exporters": [
-              "otlp/metrics"
-            ]
+        "pipelines":
+          {
+            "logs": {
+              "receivers": [
+                "filelog"
+              ],
+              "processors": [
+                "batch",
+                "memory_limiter",
+                "transform/host"
+              ],
+              "exporters": [
+                "otlp/logs"
+              ]
+            }
           }
-        }
+
       }
     }
   volumeMounts:
     - name: otel-secrets
       mountPath: "/mnt/secrets-store/otel-secrets"
+      readOnly: true
+    - name: varlog
+      mountPath: "/var/log"
       readOnly: true
   volumes:
     - name: otel-secrets
@@ -142,4 +220,6 @@ spec:
         readOnly: true
         volumeAttributes:
           secretProviderClass: "otel-secrets"
-
+    - name: varlog
+      hostPath:
+        path: /var/log

--- a/test/open-telemetry/otel-deployment-collector.yaml
+++ b/test/open-telemetry/otel-deployment-collector.yaml
@@ -170,13 +170,20 @@ spec:
                     "action": "keep",
                     "regex": "node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|process_cpu_seconds_total|process_resident_memory_bytes"
                   }
+                ],
+                "static_configs": [
+                  {
+                    "targets": [ "${MY_POD_IP}:9100" ]
+                  }
                 ]
+
               }
             ]
           }
+        },
+        "k8s_events": {
+          "namespaces": []
         }
-
-
       },
       "processors": {
         "batch": { },
@@ -184,34 +191,6 @@ spec:
           "check_interval": "5s",
           "limit_percentage": 80,
           "spike_limit_percentage": 25
-        },
-        "k8sattributes": {
-          "passthrough": true,
-          "pod_association": [
-            {
-              "sources": [
-                {
-                  "from": "resource_attribute",
-                  "name": "k8s.pod.ip"
-                }
-              ]
-            },
-            {
-              "sources": [
-                {
-                  "from": "resource_attribute",
-                  "name": "k8s.pod.uid"
-                }
-              ]
-            },
-            {
-              "sources": [
-                {
-                  "from": "connection"
-                }
-              ]
-            }
-          ]
         },
         "transform/host": {
           "metric_statements": [
@@ -250,6 +229,12 @@ spec:
           "auth": {
             "authenticator": "oauth2client/client"
           }
+        },
+        "otlp/logs": {
+          "endpoint": "https://logs.gateway.analytics.naturalis.io:443",
+          "auth": {
+            "authenticator": "oauth2client/client"
+          }
         }
       },
       "service": {
@@ -264,12 +249,24 @@ spec:
             ],
             "processors": [
               "batch",
-              "k8sattributes",
               "memory_limiter",
               "transform/host"
             ],
             "exporters": [
               "otlp/metrics"
+            ]
+          },
+          "logs": {
+            "receivers": [
+              "k8s_events"
+            ],
+            "processors": [
+              "batch",
+              "memory_limiter",
+              "transform/host"
+            ],
+            "exporters": [
+              "otlp/logs"
             ]
           }
         }

--- a/test/open-telemetry/otel-deployment-collector.yaml
+++ b/test/open-telemetry/otel-deployment-collector.yaml
@@ -21,14 +21,162 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: CLUSTER_NAME
+      value: "test-cluster"
   config:
     {
       "connectors": { },
       "receivers": {
-        "k8s_cluster": {
-          allocatable_types_to_report: [ "cpu", "memory" ],
-          "auth_type": "serviceAccount",
+        "prometheus": {
+          "config": {
+            "scrape_configs": [
+              {
+                "bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+                "job_name": "integrations/kubernetes/cadvisor",
+                "kubernetes_sd_configs": [
+                  {
+                    "role": "node"
+                  }
+                ],
+                "relabel_configs": [
+                  {
+                    "replacement": "kubernetes.default.svc.cluster.local:443",
+                    "target_label": "__address__"
+                  },
+                  {
+                    "regex": "(.+)",
+                    "replacement": "/api/v1/nodes/$${1}/proxy/metrics/cadvisor",
+                    "source_labels": [
+                      "__meta_kubernetes_node_name"
+                    ],
+                    "target_label": "__metrics_path__"
+                  }
+                ],
+                "metric_relabel_configs": [
+                  {
+                    "source_labels": [
+                      "__name__"
+                    ],
+                    "action": "keep",
+                    "regex": "container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+                  }
+                ],
+                "scheme": "https",
+                "tls_config": {
+                  "ca_file": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+                  "insecure_skip_verify": false,
+                  "server_name": "kubernetes"
+                }
+              },
+              {
+                "bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+                "job_name": "integrations/kubernetes/kubelet",
+                "kubernetes_sd_configs": [
+                  {
+                    "role": "node"
+                  }
+                ],
+                "relabel_configs": [
+                  {
+                    "replacement": "kubernetes.default.svc.cluster.local:443",
+                    "target_label": "__address__"
+                  },
+                  {
+                    "regex": "(.+)",
+                    "replacement": "/api/v1/nodes/$${1}/proxy/metrics",
+                    "source_labels": [
+                      "__meta_kubernetes_node_name"
+                    ],
+                    "target_label": "__metrics_path__"
+                  }
+                ],
+                "metric_relabel_configs": [
+                  {
+                    "source_labels": [
+                      "__name__"
+                    ],
+                    "action": "keep",
+                    "regex": "container_cpu_usage_seconds_total|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_used|kubernetes_build_info|namespace_workload_pod|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+                  }
+                ],
+                "scheme": "https",
+                "tls_config": {
+                  "ca_file": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+                  "insecure_skip_verify": false,
+                  "server_name": "kubernetes"
+                }
+              },
+              {
+                "job_name": "integrations/kubernetes/kube-state-metrics",
+                "kubernetes_sd_configs": [
+                  {
+                    "role": "pod"
+                  }
+                ],
+                "relabel_configs": [
+                  {
+                    "action": "keep",
+                    "regex": "kube-state-metrics",
+                    "source_labels": [
+                      "__meta_kubernetes_pod_label_app_kubernetes_io_name"
+                    ]
+                  }
+                ],
+                "metric_relabel_configs": [
+                  {
+                    "source_labels": [
+                      "__name__"
+                    ],
+                    "action": "keep",
+                    "regex": "kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_replicaset.*|kube_resourcequota|kube_statefulset.*"
+                  }
+                ]
+              },
+              {
+                "job_name": "integrations/node_exporter",
+                "kubernetes_sd_configs": [
+                  {
+                    "role": "pod"
+                  }
+                ],
+                "relabel_configs": [
+                  {
+                    "action": "keep",
+                    "regex": "prometheus-node-exporter.*",
+                    "source_labels": [
+                      "__meta_kubernetes_pod_label_app_kubernetes_io_name"
+                    ]
+                  },
+                  {
+                    "action": "replace",
+                    "source_labels": [
+                      "__meta_kubernetes_pod_node_name"
+                    ],
+                    "target_label": "instance"
+                  },
+                  {
+                    "action": "replace",
+                    "source_labels": [
+                      "__meta_kubernetes_namespace"
+                    ],
+                    "target_label": "namespace"
+                  }
+                ],
+                "metric_relabel_configs": [
+                  {
+                    "source_labels": [
+                      "__name__"
+                    ],
+                    "action": "keep",
+                    "regex": "node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|process_cpu_seconds_total|process_resident_memory_bytes"
+                  }
+                ]
+              }
+            ]
+          }
         }
+
+
       },
       "processors": {
         "batch": { },
@@ -70,11 +218,13 @@ spec:
             {
               "context": "datapoint",
               "statements": [
-                'set(attributes["deployment_environment"], "test-gateway")',
+                'set(attributes["deployment_environment"], "test")',
                 'set(attributes["service_namespace"], "naturalis.bii.dissco")',
                 'set(attributes["service_name"], "dissco-deploy")',
                 'set(attributes["service_owner"], "soulaine.theocharides@naturalis.nl")',
-                'set(attributes["service_team"], "dissco")'
+                'set(attributes["service_team"], "dissco")',
+                'set(attributes["cluster"], "${CLUSTER_NAME}")',
+                'set(attributes["job"], "integrations/kubernetes/eventhandler")'
               ]
             }
           ]
@@ -110,7 +260,7 @@ spec:
         "pipelines": {
           "metrics": {
             "receivers": [
-              "k8s_cluster"
+              "prometheus"
             ],
             "processors": [
               "batch",

--- a/test/open-telemetry/otel-roles.yaml
+++ b/test/open-telemetry/otel-roles.yaml
@@ -38,11 +38,13 @@ rules:
       - ''
     resources:
       - events
+      - endpoints
       - namespaces
       - namespaces/status
       - nodes
       - nodes/stats
       - nodes/spec
+      - nodes/proxy
       - pods
       - pods/status
       - replicationcontrollers
@@ -53,6 +55,10 @@ rules:
       - get
       - list
       - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:


### PR DESCRIPTION
- Uses prometheus node-exporter and kube-state-metrics to gather metrics instead of out of box otel collectors
    - Follows [this configuration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/helm-chart-config/otel-collector/#before-you-begin)
- Adds helm chart for node-exporter and kube-state metrics
- Captures logs using filelog