### PR TITLE
Feature/split kafka annotation

### DIFF
--- a/elastic-schemas/digital-specimen.json
+++ b/elastic-schemas/digital-specimen.json
@@ -983,6 +983,15 @@
                                             }
                                         }
                                     },
+                                    "ods:genusHTMLLabel": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
                                     "dwc:scientificNameAuthorship": {
                                         "type": "text",
                                         "fields": {
@@ -3569,6 +3578,15 @@
                                     }
                                 }
                             },
+                            "chrono:chronometricAgeProtocol": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "ignore_above": 256
+                                    }
+                                }
+                            },
                             "chrono:chronometricAgeUncertaintyInYears": {
                                 "type": "integer"
                             },
@@ -3632,6 +3650,152 @@
                                     "keyword": {
                                         "type": "keyword",
                                         "ignore_above": 256
+                                    }
+                                }
+                            },
+                            "ods:hasAgents": {
+                                "properties": {
+                                    "@id": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "@type": {
+                                        "type": "keyword"
+                                    },
+                                    "schema:identifier": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "schema:name": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "ods:hasRoles": {
+                                        "properties": {
+                                            "@id": {
+                                                "type": "text",
+                                                "fields": {
+                                                    "keyword": {
+                                                        "type": "keyword",
+                                                        "ignore_above": 256
+                                                    }
+                                                }
+                                            },
+                                            "@type": {
+                                                "type": "constant_keyword",
+                                                "value": "schema:Role"
+                                            },
+                                            "schema:roleName": {
+                                                "type": "text",
+                                                "fields": {
+                                                    "keyword": {
+                                                        "type": "keyword",
+                                                        "ignore_above": 256
+                                                    }
+                                                }
+                                            },
+                                            "schema:startDate": {
+                                                "type": "text",
+                                                "fields": {
+                                                    "keyword": {
+                                                        "type": "keyword",
+                                                        "ignore_above": 256
+                                                    }
+                                                }
+                                            },
+                                            "schema:endDate": {
+                                                "type": "text",
+                                                "fields": {
+                                                    "keyword": {
+                                                        "type": "keyword",
+                                                        "ignore_above": 256
+                                                    }
+                                                }
+                                            },
+                                            "schema:position": {
+                                                "type": "integer"
+                                            }
+                                        }
+                                    },
+                                    "schema:email": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "schema:url": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "ods:hasIdentifiers": {
+                                        "properties": {
+                                            "@id": {
+                                                "type": "text",
+                                                "fields": {
+                                                    "keyword": {
+                                                        "type": "keyword",
+                                                        "ignore_above": 256
+                                                    }
+                                                }
+                                            },
+                                            "@type": {
+                                                "type": "constant_keyword",
+                                                "value": "ods:Identifier"
+                                            },
+                                            "dcterms:title": {
+                                                "type": "text",
+                                                "fields": {
+                                                    "keyword": {
+                                                        "type": "keyword",
+                                                        "ignore_above": 256
+                                                    }
+                                                }
+                                            },
+                                            "dcterms:type": {
+                                                "type": "keyword"
+                                            },
+                                            "dcterms:identifier": {
+                                                "type": "text",
+                                                "fields": {
+                                                    "keyword": {
+                                                        "type": "keyword",
+                                                        "ignore_above": 256
+                                                    }
+                                                }
+                                            },
+                                            "ods:isPartOfLabel": {
+                                                "type": "boolean"
+                                            },
+                                            "ods:gupriLevel": {
+                                                "type": "keyword"
+                                            },
+                                            "ods:identifierStatus": {
+                                                "type": "keyword"
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -4852,6 +5016,15 @@
                                 }
                             },
                             "ods:scientificNameHTMLLabel": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "ignore_above": 256
+                                    }
+                                }
+                            },
+                            "ods:genusHTMLLabel": {
                                 "type": "text",
                                 "fields": {
                                     "keyword": {
@@ -7084,6 +7257,304 @@
                                                 "ignore_above": 256
                                             }
                                         }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "ods:hasChronometricAges": {
+                "properties": {
+                    "@id": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "@type": {
+                        "type": "constant_keyword",
+                        "value": "ods:ChronometricAge"
+                    },
+                    "chrono:chronometricAgeID": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:verbatimChronometricAge": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:uncalibratedChronometricAge": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:chronometricAgeConversionProtocol": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:earliestChronometricAge": {
+                        "type": "integer"
+                    },
+                    "chrono:earliestChronometricAgeReferenceSystem": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:latestChronometricAge": {
+                        "type": "integer"
+                    },
+                    "chrono:latestChronometricAgeReferenceSystem": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:chronometricAgeProtocol": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:chronometricAgeUncertaintyInYears": {
+                        "type": "integer"
+                    },
+                    "chrono:chronometricAgeUncertaintyMethod": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:materialDated": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:materialDatedID": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:materialDatedRelationship": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:chronometricAgeDeterminedDate": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:chronometricAgeReferences": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "chrono:chronometricAgeRemarks": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "ods:hasAgents": {
+                        "properties": {
+                            "@id": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "ignore_above": 256
+                                    }
+                                }
+                            },
+                            "@type": {
+                                "type": "keyword"
+                            },
+                            "schema:identifier": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "ignore_above": 256
+                                    }
+                                }
+                            },
+                            "schema:name": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "ignore_above": 256
+                                    }
+                                }
+                            },
+                            "ods:hasRoles": {
+                                "properties": {
+                                    "@id": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "@type": {
+                                        "type": "constant_keyword",
+                                        "value": "schema:Role"
+                                    },
+                                    "schema:roleName": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "schema:startDate": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "schema:endDate": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "schema:position": {
+                                        "type": "integer"
+                                    }
+                                }
+                            },
+                            "schema:email": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "ignore_above": 256
+                                    }
+                                }
+                            },
+                            "schema:url": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "ignore_above": 256
+                                    }
+                                }
+                            },
+                            "ods:hasIdentifiers": {
+                                "properties": {
+                                    "@id": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "@type": {
+                                        "type": "constant_keyword",
+                                        "value": "ods:Identifier"
+                                    },
+                                    "dcterms:title": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "dcterms:type": {
+                                        "type": "keyword"
+                                    },
+                                    "dcterms:identifier": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "ods:isPartOfLabel": {
+                                        "type": "boolean"
+                                    },
+                                    "ods:gupriLevel": {
+                                        "type": "keyword"
+                                    },
+                                    "ods:identifierStatus": {
+                                        "type": "keyword"
                                     }
                                 }
                             }

--- a/test/annotation/annotation-processor-kafka-auto.yaml
+++ b/test/annotation/annotation-processor-kafka-auto.yaml
@@ -41,8 +41,6 @@ spec:
               value: elastic-search-es-http.elastic.svc.cluster.local
             - name: elasticsearch.port
               value: "9200"
-            - name: application.batch-page-size
-              value: "50"
             - name: elasticsearch.username
               valueFrom:
                 secretKeyRef:

--- a/test/annotation/annotation-processor-kafka-auto.yaml
+++ b/test/annotation/annotation-processor-kafka-auto.yaml
@@ -1,34 +1,30 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dissco-core-annotation-processing-kafka
+  name: dissco-core-annotation-processing-kafka-auto
   labels:
-    app: dissco-core-annotation-processing-kafka
+    app: dissco-core-annotation-processing-kafka-auto
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dissco-core-annotation-processing-kafka
+      app: dissco-core-annotation-processing-kafka-auto
   template:
     metadata:
       labels:
-        app: dissco-core-annotation-processing-kafka
+        app: dissco-core-annotation-processing-kafka-auto
         language: java
-      annotations:
-        co.elastic.logs/multiline.pattern: '^[[:space:]]+(at|\.{3})[[:space:]]+\b|^Caused by:'
-        co.elastic.logs/multiline.negate: "false"
-        co.elastic.logs/multiline.match: after
     spec:
       automountServiceAccountToken: false
       containers:
-        - name: dissco-core-annotation-processing-kafka
+        - name: dissco-core-annotation-processing-kafka-auto
           image: public.ecr.aws/dissco/dissco-core-annotation-processing-service
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
           env:
             - name: spring.profiles.active
-              value: kafka
+              value: kafka-auto
             - name: spring.datasource.url
               value: jdbc:postgresql://terraform-20230822143945532600000001.cbppwfnjypll.eu-west-2.rds.amazonaws.com:5432/dissco
             - name: spring.datasource.username
@@ -66,8 +62,6 @@ spec:
             - name: kafka.consumer.group
               value: group
             - name: kafka.consumer.topic
-              value: annotation
-            - name: kafka.consumer.topic.auto-accepted
               value: auto-accepted-annotation
             - name: spring.security.oauth2.resourceserver.jwt.issuer-uri
               value: https://login-demo.dissco.eu/auth/realms/dissco
@@ -92,7 +86,7 @@ spec:
               cpu: "200m"
             limits:
               memory: "500Mi"
-              cpu: "1000m"
+              cpu: "750m"
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
@@ -112,19 +106,13 @@ spec:
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: dissco-core-annotation-processing-kafka-scaled-object
+  name: dissco-core-annotation-processing-kafka-auto-scaled-object
 spec:
   scaleTargetRef:
-    name: dissco-core-annotation-processing-kafka
-  minReplicaCount: 1
+    name: dissco-core-annotation-processing-kafka-auto
+  minReplicaCount: 0
   maxReplicaCount:  5
   triggers:
-    - type: kafka
-      metadata:
-        bootstrapServers: kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
-        consumerGroup: group
-        topic: annotation
-        lagThreshold: '5'
     - type: kafka
       metadata:
         bootstrapServers: kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/test/annotation/annotation-processor-kafka-mas.yaml
+++ b/test/annotation/annotation-processor-kafka-mas.yaml
@@ -1,0 +1,121 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dissco-core-annotation-processing-kafka-mas
+  labels:
+    app: dissco-core-annotation-processing-kafka-mas
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dissco-core-annotation-processing-kafka-mas
+  template:
+    metadata:
+      labels:
+        app: dissco-core-annotation-processing-kafka-mas
+        language: java
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: dissco-core-annotation-processing-kafka-mas
+          image: public.ecr.aws/dissco/dissco-core-annotation-processing-service
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          env:
+            - name: spring.profiles.active
+              value: kafka-mas
+            - name: spring.datasource.url
+              value: jdbc:postgresql://terraform-20230822143945532600000001.cbppwfnjypll.eu-west-2.rds.amazonaws.com:5432/dissco
+            - name: spring.datasource.username
+              valueFrom:
+                secretKeyRef:
+                  name: db-secrets
+                  key: db-username
+            - name: spring.datasource.password
+              valueFrom:
+                secretKeyRef:
+                  name: db-secrets
+                  key: db-password
+            - name: elasticsearch.hostname
+              value: elastic-search-es-http.elastic.svc.cluster.local
+            - name: elasticsearch.port
+              value: "9200"
+            - name: application.batch-page-size
+              value: "50"
+            - name: elasticsearch.username
+              valueFrom:
+                secretKeyRef:
+                  name: aws-secrets
+                  key: elastic-username
+            - name: elasticsearch.password
+              valueFrom:
+                secretKeyRef:
+                  name: aws-secrets
+                  key: elastic-password
+            - name: elasticsearch.index-name
+              value: annotation
+            - name: kafka.publisher.host
+              value: kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+            - name: kafka.consumer.host
+              value: kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+            - name: kafka.consumer.group
+              value: group
+            - name: kafka.consumer.topic
+              value: annotation
+            - name: spring.security.oauth2.resourceserver.jwt.issuer-uri
+              value: https://login-demo.dissco.eu/auth/realms/dissco
+            - name: token.id
+              value: demo-api-client
+            - name: token.grantType
+              value: client_credentials
+            - name: token.secret
+              valueFrom:
+                secretKeyRef:
+                  name: aws-secrets
+                  key: handle-endpoint-token
+            - name: endpoint.handle-endpoint
+              value: https://dev.dissco.tech/handle-manager/api/v1/pids/
+            - name: endpoint.token-endpoint
+              value: https://login-demo.dissco.eu/auth/realms/dissco/protocol/openid-connect/token
+            - name: application.processor-handle
+              value: https://hdl.handle.net/20.5000.1025/ANNOTATION-PROCESSOR
+          resources:
+            requests:
+              memory: "500Mi"
+              cpu: "200m"
+            limits:
+              memory: "500Mi"
+              cpu: "750m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 60
+            failureThreshold: 2
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: dissco-core-annotation-processing-kafka-mas-scaled-object
+spec:
+  scaleTargetRef:
+    name: dissco-core-annotation-processing-kafka-mas
+  minReplicaCount: 0
+  maxReplicaCount:  5
+  triggers:
+    - type: kafka
+      metadata:
+        bootstrapServers: kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+        consumerGroup: group
+        topic: annotation
+        lagThreshold: '5'

--- a/test/annotation/annotation-processor-kafka-mas.yaml
+++ b/test/annotation/annotation-processor-kafka-mas.yaml
@@ -41,8 +41,6 @@ spec:
               value: elastic-search-es-http.elastic.svc.cluster.local
             - name: elasticsearch.port
               value: "9200"
-            - name: application.batch-page-size
-              value: "50"
             - name: elasticsearch.username
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
- Split kafka-annotation in two separate auto-scaling deployments
- Remove standard instance of 1 (not necessary)
- Removed batchSize, not needed now we have searchAfter