### PR TITLE
Feature/acc release 1.0.2 alpha and fixes

### DIFF
--- a/acceptance/annotation/annotation-processor-kafka-mas.yaml
+++ b/acceptance/annotation/annotation-processor-kafka-mas.yaml
@@ -108,7 +108,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: dissco-core-annotation-processing-kafka-mas
-  minReplicaCount: 0
+  minReplicaCount: 1
   maxReplicaCount:  2
   triggers:
     - type: kafka

--- a/release/release-notes/v1.1.0.md
+++ b/release/release-notes/v1.1.0.md
@@ -1,0 +1,84 @@
+# Release v1.1.0
+production release - Mar-31-2025
+
+## dissco-core-backend
+* remove latest annotation endpoint 
+* fix trivy 
+* elvis services 
+* remove proxy for elvis 
+* swagger 
+* Elastic Search Improvements - Wildcard support, documentation, adds "habitat" search term 
+* MJR /creator endpoint was searching the repo for job id, not orcid 
+* Mjr endpoint needs to be authenticated
+
+## dissco-nusearch-service
+* trivy 
+* update to hasCOLID
+
+## handle-manager
+* Bug fix/normalize media 
+* trivy cache 
+* github cache 
+* Feature/swagger 
+* Flexible FDO lookup -> uses name and profile too now 
+* Batch Auto Annotations - Reduce response for annotation requests 
+* Trivy shouldnt break merge pipleline
+
+## dissco-data-exporter-backend
+* always run new job 
+* trivy cache
+
+## dissco-export-job
+No change since last release
+
+
+## dissco-core-digital-specimen-processor
+* Term selector fix 
+* fix trivy cache workflow 
+* cache 
+* testing 
+* Fix interrupted exception 
+* Bug fix/cache keycloak token
+
+## disscover-production
+* Encode URI to get MAS job Record 
+* Mjr creator endpoint doesn't explicitly need orcid
+
+## orchestration-frontend
+No change since last release
+## dissco-core-provenance-service
+* trivy
+
+## dissco-core-orchestration-backend
+* update trivy 
+* Don't run invalid source systems 
+* Adds Filters to source system !Data model changes
+
+## dissco-core-translator
+* trivy cache 
+* Ensure media items are unique per specimen 
+* Bug fix/associated media pipeline 
+* Revert "Bug fix/associated media pipeline" 
+* Bug fix/associated media pipeline 
+* Biocase Exception Handling  
+* Uses filters for biocase endpoint 
+* Extending dwca translation - Table naming, mapping ac:accessURI to dcterms:references
+
+## dissco-core-annotation-processing-service
+* trivy cache 
+* Feature/full swagger endpoint 
+* Update interrupted exception processing 
+* Cache keycloak token, fix rollback creation 
+* MASs should be able to mark something as failed  !DB changes
+
+## datacite-publisher
+* Feature/logging
+
+## dissco-core-digital-media-object-processor
+* Change FieldSelector to TermSelector 
+* trivy cache 
+* trivy cache 
+* Hotfix/trivy cache 1 
+* cache keycloak token 
+* Cache keycloak token
+


### PR DESCRIPTION
- Adds production release notes (from previous PR)
- Creates acceptance release (already out)
- Issue: DiSSCover creates github commit tags differently from the rest of infrastructure. for now, we need to manually compile release notes for disscover. I don't anticipate much activity in disscover this month, but I made a [ticket](https://naturalis.atlassian.net/browse/DD-1659) to align disscover workflow with the rest of our services 