### PR TITLE
Fix repoURL for rabbit

### DIFF
--- a/test-helm-resources/templates/rabbitmq-argocd.yaml
+++ b/test-helm-resources/templates/rabbitmq-argocd.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     chart: rabbitmq-cluster-operator
-    repoURL: oci://registry-1.docker.io/bitnamicharts
+    repoURL: registry-1.docker.io/bitnamicharts
     targetRevision: 4.4.7
     helm:
       releaseName: rabbitmq-operator


### PR DESCRIPTION
OCI needs to be removed when using argoCD 
See https://argo-cd.readthedocs.io/en/stable/user-guide/helm/