### PR TITLE
Deployment changes for MAS rabbitMQ

### DIFF
--- a/test-helm-resources/templates/rabbitmq-argocd.yaml
+++ b/test-helm-resources/templates/rabbitmq-argocd.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: rabbitmq-cluster-operator
     repoURL: registry-1.docker.io/bitnamicharts
-    targetRevision: 4.4.7
+    targetRevision: 4.4.11
     helm:
       releaseName: rabbitmq-operator
   destination:

--- a/test/machine-annotation-service/mas-rabbitmq.yaml
+++ b/test/machine-annotation-service/mas-rabbitmq.yaml
@@ -1,0 +1,12 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: mas-exchange
+  namespace: machine-annotation-services
+spec:
+  name: mas-exchange # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+    namespace: rabbitmq

--- a/test/orchestration-backend/orchestration-backend-roles.yaml
+++ b/test/orchestration-backend/orchestration-backend-roles.yaml
@@ -18,6 +18,9 @@ rules:
   - apiGroups: ["keda.sh"] # "" indicates the core API group
     resources: ["scaledobjects"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [ "rabbitmq.com" ] # "" indicates the core API group
+    resources: [ "bindings", "queues" ]
+    verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/test/orchestration-backend/orchestration-backend.yaml
+++ b/test/orchestration-backend/orchestration-backend.yaml
@@ -42,10 +42,18 @@ spec:
               value: ${spring.security.oauth2.resourceserver.jwt.issuer-uri}/protocol/openid-connect/certs
             - name: jwt.auth.converter.resource-id
               value: springboot-keycloak-client
-            - name: kafka.publisher.host
-              value: kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
-            - name: mas.kafkaHost
-              value: kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+            - name: spring.rabbitmq.password
+              valueFrom:
+                secretKeyRef:
+                  name: aws-secrets
+                  key: rabbitmq-password
+            - name: spring.rabbitmq.username
+              valueFrom:
+                secretKeyRef:
+                  name: aws-secrets
+                  key: rabbitmq-username
+            - name: spring.rabbitmq.host
+              value: rabbitmq-cluster.rabbitmq.svc.cluster.local
             - name: token.id
               value: demo-api-client
             - name: token.grant-type

--- a/test/rabbitmq/rabbitmq-cluster.yaml
+++ b/test/rabbitmq/rabbitmq-cluster.yaml
@@ -3,6 +3,8 @@ kind: RabbitmqCluster
 metadata:
   name: rabbitmq-cluster
   namespace: rabbitmq
+  annotations:
+    rabbitmq.com/topology-allowed-namespaces: "machine-annotation-services"
 spec:
   replicas: 3
   rabbitmq:
@@ -14,5 +16,5 @@ spec:
     additionalConfig: |
       cluster_partition_handling = pause_minority
   persistence:
-    storageClassName: gp2
+    storageClassName: gp3
     storage: "100Gi"


### PR DESCRIPTION
- Some small changes
- Updated rabbitMQ to latest version
- Add mas-exchange 
- Add roles to orchestration backend to allow management of k8s queues and bindings
- Orch backend missed rabbit properties
- Switch rabbit to new storage class (gp3)
- Indicated that the operator should also check for Rabbit resources in mas namespace