### PR TITLE
Feature/add rabbitmq resources

### DIFF
--- a/acceptance-helm-resources/templates/rabbitmq-argocd.yaml
+++ b/acceptance-helm-resources/templates/rabbitmq-argocd.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rabbitmq-argocd
+  namespace: argocd
+spec:
+  project: default
+  source:
+    chart: rabbitmq-cluster-operator
+    repoURL: registry-1.docker.io/bitnamicharts
+    targetRevision: 4.4.11
+    helm:
+      releaseName: rabbitmq-operator
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: rabbitmq

--- a/acceptance/annotation/auto-accepted-annotation-rabbitmq-dlq.yaml
+++ b/acceptance/annotation/auto-accepted-annotation-rabbitmq-dlq.yaml
@@ -1,0 +1,37 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: auto-accepted-annotation-exchange-dlq
+  namespace: rabbitmq
+spec:
+  name: auto-accepted-annotation-exchange-dlq # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: auto-accepted-annotation-binding-dlq
+  namespace: rabbitmq
+spec:
+  source: auto-accepted-annotation-exchange-dlq # an existing exchange
+  destination: auto-accepted-annotation-queue-dlq # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "auto-accepted-annotation-dlq"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: auto-accepted-annotation-queue-dlq # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: auto-accepted-annotation-queue-dlq # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/annotation/auto-accepted-annotation-rabbitmq.yaml
+++ b/acceptance/annotation/auto-accepted-annotation-rabbitmq.yaml
@@ -1,0 +1,52 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: auto-accepted-annotation-exchange
+  namespace: rabbitmq
+spec:
+  name: auto-accepted-annotation-exchange # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: auto-accepted-annotation-binding
+  namespace: rabbitmq
+spec:
+  source: auto-accepted-annotation-exchange # an existing exchange
+  destination: auto-accepted-annotation-queue # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "auto-accepted-annotation"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: auto-accepted-annotation-dlq-policy # name of this custom resource
+  namespace: rabbitmq
+spec:
+  name: auto-accepted-annotation-dlq-policy
+  pattern: "auto-accepted-annotation-queue"
+  applyTo: "queues"
+  definition:
+    dead-letter-exchange: auto-accepted-annotation-exchange-dlq
+    dead-letter-routing-key: auto-accepted-annotation-dlq
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: auto-accepted-annotation-queue # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: auto-accepted-annotation-queue # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/annotation/mas-annotation-failed-rabbitmq.yaml
+++ b/acceptance/annotation/mas-annotation-failed-rabbitmq.yaml
@@ -1,0 +1,37 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: mas-annotation-failed-exchange
+  namespace: rabbitmq
+spec:
+  name: mas-annotation-failed-exchange # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: mas-annotation-failed-binding
+  namespace: rabbitmq
+spec:
+  source: mas-annotation-failed-exchange # an existing exchange
+  destination: mas-annotation-failed-queue # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "mas-annotation-failed"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: mas-annotation-failed-queue # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: mas-annotation-failed-queue # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/annotation/mas-annotation-rabbitmq-dlq.yaml
+++ b/acceptance/annotation/mas-annotation-rabbitmq-dlq.yaml
@@ -1,0 +1,37 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: mas-annotation-exchange-dlq
+  namespace: rabbitmq
+spec:
+  name: mas-annotation-exchange-dlq # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: mas-annotation-binding-dlq
+  namespace: rabbitmq
+spec:
+  source: mas-annotation-exchange-dlq # an existing exchange
+  destination: mas-annotation-queue-dlq # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "mas-annotation-dlq"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: mas-annotation-queue-dlq # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: mas-annotation-queue-dlq # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/annotation/mas-annotation-rabbitmq.yaml
+++ b/acceptance/annotation/mas-annotation-rabbitmq.yaml
@@ -1,0 +1,52 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: mas-annotation-exchange
+  namespace: rabbitmq
+spec:
+  name: mas-annotation-exchange # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: mas-annotation-binding
+  namespace: rabbitmq
+spec:
+  source: mas-annotation-exchange # an existing exchange
+  destination: mas-annotation-queue # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "mas-annotation"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: mas-annotation-dlq-policy # name of this custom resource
+  namespace: rabbitmq
+spec:
+  name: mas-annotation-dlq-policy
+  pattern: "mas-annotation-queue"
+  applyTo: "queues"
+  definition:
+    dead-letter-exchange: mas-annotation-exchange-dlq
+    dead-letter-routing-key: mas-annotation-dlq
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: mas-annotation-queue # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: mas-annotation-queue # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/datacite-publisher/doi-rabbitmq-dlq.yaml
+++ b/acceptance/datacite-publisher/doi-rabbitmq-dlq.yaml
@@ -1,0 +1,89 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: doi-exchange-dlq
+  namespace: rabbitmq
+spec:
+  name: doi-exchange-dlq # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: specimen-doi-binding-dlq
+  namespace: rabbitmq
+spec:
+  source: doi-exchange-dlq # an existing exchange
+  destination: specimen-doi-queue-dlq # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "specimen-doi-dlq"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: media-doi-binding-dlq
+  namespace: rabbitmq
+spec:
+  source: doi-exchange-dlq # an existing exchange
+  destination: media-doi-queue-dlq # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "media-doi-dlq"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: tombstone-doi-binding-dlq
+  namespace: rabbitmq
+spec:
+  source: doi-exchange-dlq # an existing exchange
+  destination: tombstone-doi-queue-dlq # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "tombstone-doi-dlq"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: specimen-doi-queue-dlq # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: specimen-doi-queue-dlq # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: media-doi-queue-dlq # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: media-doi-queue-dlq # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: tombstone-doi-queue-dlq # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: tombstone-doi-queue-dlq # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/datacite-publisher/doi-rabbitmq.yaml
+++ b/acceptance/datacite-publisher/doi-rabbitmq.yaml
@@ -1,0 +1,137 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: doi-exchange
+  namespace: rabbitmq
+spec:
+  name: doi-exchange # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: specimen-doi-binding
+  namespace: rabbitmq
+spec:
+  source: doi-exchange # an existing exchange
+  destination: specimen-doi-queue # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "specimen-doi-routing-key"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: media-doi-binding
+  namespace: rabbitmq
+spec:
+  source: doi-exchange # an existing exchange
+  destination: media-doi-queue # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "media-doi-routing-key"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: tombstone-doi-binding
+  namespace: rabbitmq
+spec:
+  source: doi-exchange # an existing exchange
+  destination: tombstone-doi-queue # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "tombstone-doi-routing-key"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: specimen-doi-dlq-policy # name of this custom resource
+  namespace: rabbitmq
+spec:
+  name: media-doi-dlq-policy
+  pattern: "specimen-doi-queue"
+  applyTo: "queues"
+  definition:
+    dead-letter-exchange: doi-exchange-dlq
+    dead-letter-routing-key: specimen-doi-dlq
+    delivery-limit: 2
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: media-doi-dlq-policy # name of this custom resource
+  namespace: rabbitmq
+spec:
+  name: media-doi-dlq-policy
+  pattern: "media-doi-queue"
+  applyTo: "queues"
+  definition:
+    dead-letter-exchange: doi-exchange-dlq
+    dead-letter-routing-key: media-doi-dlq
+    delivery-limit: 2
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: tombstone-doi-dlq-policy # name of this custom resource
+  namespace: rabbitmq
+spec:
+  name: tombstone-doi-dlq-policy
+  pattern: "tombstone-doi-queue"
+  applyTo: "queues"
+  definition:
+    dead-letter-exchange: doi-exchange-dlq
+    dead-letter-routing-key: tombstone-doi-dlq
+    delivery-limit: 2
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: specimen-doi-queue # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: specimen-doi-queue # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: media-doi-queue # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: media-doi-queue # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: tombstone-doi-queue # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: tombstone-doi-queue # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/digital-specimen/digital-specimen-rabbitmq-dlq.yaml
+++ b/acceptance/digital-specimen/digital-specimen-rabbitmq-dlq.yaml
@@ -1,0 +1,37 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: digital-specimen-exchange-dlq
+  namespace: rabbitmq
+spec:
+  name: digital-specimen-exchange-dlq # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: digital-specimen-binding-dlq
+  namespace: rabbitmq
+spec:
+  source: digital-specimen-exchange-dlq # an existing exchange
+  destination: digital-specimen-queue-dlq # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "digital-specimen-dlq"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: digital-specimen-queue-dlq # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: digital-specimen-queue-dlq # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/digital-specimen/digital-specimen-rabbitmq.yaml
+++ b/acceptance/digital-specimen/digital-specimen-rabbitmq.yaml
@@ -1,0 +1,53 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: digital-specimen-exchange
+  namespace: rabbitmq
+spec:
+  name: digital-specimen-exchange # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: digital-specimen-binding
+  namespace: rabbitmq
+spec:
+  source: digital-specimen-exchange # an existing exchange
+  destination: digital-specimen-queue # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "digital-specimen"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: digital-specimen-dlq-policy # name of this custom resource
+  namespace: rabbitmq
+spec:
+  name: digital-specimen-dlq-policy
+  pattern: "digital-specimen-queue"
+  applyTo: "queues"
+  definition:
+    dead-letter-exchange: digital-specimen-exchange-dlq
+    dead-letter-routing-key: digital-specimen-dlq
+    delivery-limit: 2
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: digital-specimen-queue # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: digital-specimen-queue # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/handle-manager/doi-rabbitmq-dlq.yaml
+++ b/acceptance/handle-manager/doi-rabbitmq-dlq.yaml
@@ -1,0 +1,89 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: doi-exchange-dlq
+  namespace: rabbitmq
+spec:
+  name: doi-exchange-dlq # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: media-doi-binding-dlq
+  namespace: rabbitmq
+spec:
+  source: doi-exchange-dlq # an existing exchange
+  destination: media-doi-queue-dlq # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "media-doi-dlq"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: media-doi-queue-dlq # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: media-doi-queue-dlq # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: specimen-doi-binding-dlq
+  namespace: rabbitmq
+spec:
+  source: doi-exchange-dlq # an existing exchange
+  destination: specimen-doi-queue-dlq # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "specimen-doi-dlq"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: specimen-doi-queue-dlq # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: specimen-doi-queue-dlq # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: tombstone-doi-binding-dlq
+  namespace: rabbitmq
+spec:
+  source: doi-exchange-dlq # an existing exchange
+  destination: tombstone-doi-queue-dlq # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "tombstone-doi-dlq"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: tombstone-doi-queue-dlq # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: tombstone-doi-queue-dlq # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/handle-manager/doi-rabbitmq.yaml
+++ b/acceptance/handle-manager/doi-rabbitmq.yaml
@@ -1,0 +1,134 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: doi-exchange
+  namespace: rabbitmq
+spec:
+  name: doi-exchange # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: media-doi-binding
+  namespace: rabbitmq
+spec:
+  source: doi-exchange # an existing exchange
+  destination: media-doi-queue # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "media-doi-routing-key"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: media-doi-queue # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: media-doi-queue # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: media-doi-dlq-policy # name of this custom resource
+  namespace: rabbitmq
+spec:
+  name: media-doi-dlq-policy
+  pattern: "media-doi-queue"
+  applyTo: "queues"
+  definition:
+    dead-letter-exchange: doi-exchange-dlq
+    dead-letter-routing-key: media-doi-dlq
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: specimen-doi-binding
+  namespace: rabbitmq
+spec:
+  source: doi-exchange # an existing exchange
+  destination: specimen-doi-queue # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "specimen-doi-routing-key"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: specimen-doi-queue # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: specimen-doi-queue # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: specimen-doi-dlq-policy # name of this custom resource
+  namespace: rabbitmq
+spec:
+  name: specimen-doi-dlq-policy
+  pattern: "specimen-doi-queue"
+  applyTo: "queues"
+  definition:
+    dead-letter-exchange: doi-exchange-dlq
+    dead-letter-routing-key: specimen-doi-dlq
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: tombstone-doi-binding
+  namespace: rabbitmq
+spec:
+  source: doi-exchange # an existing exchange
+  destination: tombstone-doi-queue # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "tombstone-doi-routing-key"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: tombstone-doi-queue # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: tombstone-doi-queue # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: tombstone-doi-dlq-policy # name of this custom resource
+  namespace: rabbitmq
+spec:
+  name: tombstone-doi-dlq-policy
+  pattern: "tombstone-doi-queue"
+  applyTo: "queues"
+  definition:
+    dead-letter-exchange: doi-exchange-dlq
+    dead-letter-routing-key: tombstone-doi-dlq
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster

--- a/acceptance/machine-annotaion-service/mas-rabbitmq.yaml
+++ b/acceptance/machine-annotaion-service/mas-rabbitmq.yaml
@@ -1,0 +1,12 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: mas-exchange
+  namespace: machine-annotation-services
+spec:
+  name: mas-exchange # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+    namespace: rabbitmq

--- a/acceptance/machine-annotaion-service/rabbitmq-authentication.yaml
+++ b/acceptance/machine-annotaion-service/rabbitmq-authentication.yaml
@@ -1,0 +1,10 @@
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-trigger-auth-rabbitmq-conn
+  namespace: machine-annotation-services
+spec:
+  secretTargetRef:
+    - parameter: host
+      name: aws-secrets
+      key: rabbitmq-host-full

--- a/acceptance/nu-search/nu-search-rabbitmq-dlq.yaml
+++ b/acceptance/nu-search/nu-search-rabbitmq-dlq.yaml
@@ -1,0 +1,37 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: nu-search-exchange-dlq
+  namespace: rabbitmq
+spec:
+  name: nu-search-exchange-dlq # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: nu-search-binding-dlq
+  namespace: rabbitmq
+spec:
+  source: nu-search-exchange-dlq # an existing exchange
+  destination: nu-search-queue-dlq # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "nu-search-dlq"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: nu-search-queue-dlq # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: nu-search-queue-dlq # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/nu-search/nu-search-rabbitmq.yaml
+++ b/acceptance/nu-search/nu-search-rabbitmq.yaml
@@ -1,0 +1,52 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: nu-search-exchange
+  namespace: rabbitmq
+spec:
+  name: nu-search-exchange # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: nu-search-binding
+  namespace: rabbitmq
+spec:
+  source: nu-search-exchange # an existing exchange
+  destination: nu-search-queue # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "nu-search"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: nu-search-dlq-policy # name of this custom resource
+  namespace: rabbitmq
+spec:
+  name: nu-search-dlq-policy
+  pattern: "nu-search-queue"
+  applyTo: "queues"
+  definition:
+    dead-letter-exchange: nu-search-exchange-dlq
+    dead-letter-routing-key: nu-search-dlq
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: nu-search-queue # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: nu-search-queue # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/provenance/provenance-rabbitmq-dlq.yaml
+++ b/acceptance/provenance/provenance-rabbitmq-dlq.yaml
@@ -1,0 +1,37 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: create-update-tombstone-exchange-dlq
+  namespace: rabbitmq
+spec:
+  name: create-update-tombstone-exchange-dlq # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: create-update-tombstone-binding-dlq
+  namespace: rabbitmq
+spec:
+  source: create-update-tombstone-exchange-dlq # an existing exchange
+  destination: create-update-tombstone-queue-dlq # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "create-update-tombstone-dlq"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: create-update-tombstone-queue-dlq # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: create-update-tombstone-queue-dlq # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/provenance/provenance-rabbitmq.yaml
+++ b/acceptance/provenance/provenance-rabbitmq.yaml
@@ -1,0 +1,52 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: create-update-tombstone-exchange
+  namespace: rabbitmq
+spec:
+  name: create-update-tombstone-exchange # name of the exchange
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Binding
+metadata:
+  name: create-update-tombstone-binding
+  namespace: rabbitmq
+spec:
+  source: create-update-tombstone-exchange # an existing exchange
+  destination: create-update-tombstone-queue # an existing queue
+  destinationType: queue # can be 'queue' or 'exchange'
+  routingKey: "create-update-tombstone"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: create-update-tombstone-dlq-policy # name of this custom resource
+  namespace: rabbitmq
+spec:
+  name: create-update-tombstone-dlq-policy
+  pattern: "create-update-tombstone-queue"
+  applyTo: "queues"
+  definition:
+    dead-letter-exchange: create-update-tombstone-exchange-dlq
+    dead-letter-routing-key: create-update-tombstone-dlq
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: create-update-tombstone-queue # name of this custom resource; does not have to the same as the actual queue name
+  namespace: rabbitmq
+spec:
+  name: create-update-tombstone-queue # name of the queue
+  autoDelete: false
+  durable: true
+  type: "quorum"
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster # name of the RabbitMQ cluster

--- a/acceptance/rabbitmq/rabbitmq-cluster.yaml
+++ b/acceptance/rabbitmq/rabbitmq-cluster.yaml
@@ -1,0 +1,20 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: rabbitmq-cluster
+  namespace: rabbitmq
+  annotations:
+    rabbitmq.com/topology-allowed-namespaces: "machine-annotation-services"
+spec:
+  replicas: 3
+  rabbitmq:
+    additionalPlugins:
+      - rabbitmq_management
+      - rabbitmq_shovel
+      - rabbitmq_shovel_management
+      - rabbitmq_prometheus
+    additionalConfig: |
+      cluster_partition_handling = pause_minority
+  persistence:
+    storageClassName: gp3
+    storage: "100Gi"


### PR DESCRIPTION
Adds the following rabbit mq resouces to the acceptance environment: 
- helm chart
- rabbit mq cluster
- Annotation: accepted queue/dlq, mas queue/dlq, mas failed queue
- digital specimen: digital specimen queue + dlq
- handle-manager: doi queue + dlq, handle queue + dlq
- mas: mas exchange, mas authentication
- nu search: queue + dlq
- prov service: queue + dlq
- datacite: queue (specimen, media, tombstone) + dlqs (see [datacite prs](https://github.com/DiSSCo/datacite-publisher/pulls) on the datacite repo and deployment repo) 

Once deployed, we can retrieve our user secrets and update 