### PR TITLE
Db migration cleanup

### DIFF
--- a/acceptance/flyway/README.md
+++ b/acceptance/flyway/README.md
@@ -1,0 +1,46 @@
+## Database Migration Process
+
+This directory manages automated database migrations. This allows us to automatically synchronize code changes with
+database changes. While these kinds of changes are done manually in the test environment, they should be automatic in
+acceptance and production.
+
+### Making a change to the database
+
+1. The developer adds a migration into the `migration-configmap.yaml` and makes a pull request. This pull request should
+   also
+   contain code changes (i.e. the updated image of the code which responds to the database changes)
+2. Database changes are merged into the main GitHub branch
+3. ArgoCD deploys the presync hooks before any other changes are applied. In this case, the `flyway-job` is deployed as
+   a kubernetes job.
+4. Flyway makes the database changes
+5. ArgoCD applies the manifests. Code changes that rely on the new database schema are safely deployed.
+
+### No-change flow
+
+If a pull request is made with no changes to the `migration-configmap`:
+
+1. ArgoCd deploys the presync hook. Flyway is deployed as a kubernetes job.
+2. Flyway sees there are no new migrations. No changes are made to the database
+3. ArgocCD applies the manifests as normal.
+
+Note: ArgoCD will always run the presync hooks, regardless of whether or not they've changed.
+
+## Naming Migrations
+
+Versioned flyway migrations follow the following naming convention:
+
+`V<Version>__<Description>.sql`
+
+We can align flyway's naming convention with the release naming convention of DiSSCo. When releasing to production or
+acceptance, we should make sure the version of the flyway migration always matches the new release version. (e.g.
+1.2.1).
+
+To track what is the latest version of the database schema, and thus to manage Flyway versions, the latest migration
+script should be kept. This will not trigger any changes in the database if re-run. Older database migration scripts
+should be removed to keep the configmap clean.
+
+## Managing the ConfigMap
+
+Once a migration is completed, the migration script in `migration-configmap.yaml` can be removed. Completed migrations
+should be moved to the `completed-migrations` directory. To prevent the migration configmap from getting too large, only
+the latest release's migration should be stored there. The file should be renamed to the release version, e.g. `database-migration-v1.2.3.yaml`

--- a/acceptance/flyway/db-secrets-flyway.yaml
+++ b/acceptance/flyway/db-secrets-flyway.yaml
@@ -1,0 +1,23 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: db-secrets-flyway
+  namespace: flyway
+spec:
+  provider: aws
+  secretObjects:
+    - secretName: db-secrets-flyway
+      type: Opaque
+      data:
+        - objectName: db-username
+          key: db-username
+        - objectName: db-password
+          key: db-password
+  parameters:
+    objects: |
+      - objectName: "arn:aws:secretsmanager:eu-west-2:824841205322:secret:rds!db-d436dbc9-2531-4309-9968-ebd53bcc1c79-iKV0Fs"
+        jmesPath:
+            - path: "username"
+              objectAlias: "db-username"
+            - path: "password"
+              objectAlias: "db-password"

--- a/acceptance/flyway/flyway-job.yaml
+++ b/acceptance/flyway/flyway-job.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: db-migration-
+  namespace: flyway
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+spec:
+  template:
+    spec:
+      serviceAccountName: flyway-secret-manager
+      automountServiceAccountToken: true
+      containers:
+        - name: flyway
+          image: redgate/flyway:11-alpine
+          args:
+            - info
+            - repair
+            - migrate
+            - info
+          env:
+            - name: FLYWAY_URL
+              value: "jdbc:postgresql://terraform-20230828064251677200000001.cbppwfnjypll.eu-west-2.rds.amazonaws.com:5432/dissco"
+            - name: FLYWAY_USER
+              valueFrom:
+                secretKeyRef:
+                  name: db-secrets-flyway
+                  key: db-username
+            - name: FLYWAY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-secrets-flyway
+                  key: db-password
+            - name: FLYWAY_BASELINE_ON_MIGRATE
+              value: "true"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+          volumeMounts:
+          - mountPath: /flyway/sql
+            name: sql
+          - name: db-secrets-flyway
+            mountPath: "/mnt/secrets-store/db-secrets-flyway"
+            readOnly: true
+      volumes:
+        - name: sql
+          configMap:
+            name: migration-configmap
+        - name: db-secrets-flyway
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "db-secrets-flyway"
+      restartPolicy: Never

--- a/acceptance/flyway/flyway-namespace.yaml
+++ b/acceptance/flyway/flyway-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flyway

--- a/acceptance/flyway/flyway-service-account.yaml
+++ b/acceptance/flyway/flyway-service-account.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flyway-secret-manager
+  namespace: flyway
+  annotations: {
+    eks.amazonaws.com/role-arn: "arn:aws:iam::824841205322:role/secret-manager"
+  }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-role-flyway
+  namespace: flyway
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-secrets-binding-flyway
+subjects:
+  - kind: ServiceAccount
+    name: flyway-secret-manager
+    namespace: flyway
+roleRef:
+  kind: Role
+  name: secret-role-flyway
+  apiGroup: rbac.authorization.k8s.io

--- a/acceptance/flyway/migration-configmap.yaml
+++ b/acceptance/flyway/migration-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: migration-configmap
+  namespace: flyway
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+data:

--- a/test/flyway/README.md
+++ b/test/flyway/README.md
@@ -35,7 +35,12 @@ We can align flyway's naming convention with the release naming convention of Di
 acceptance, we should make sure the version of the flyway migration always matches the new release version. (e.g.
 1.2.1).
 
-Once a migration is completed, the migration script in `migration-configmap.yaml` can be removed. To track
-what is the latest version of the database schema, and thus to manage Flyway versions, the latest migration script
-should be kept. This will not trigger any changes in the database if re-run. Older database migration scripts should be
-removed to keep the configmap clean. 
+To track what is the latest version of the database schema, and thus to manage Flyway versions, the latest migration
+script should be kept. This will not trigger any changes in the database if re-run. Older database migration scripts
+should be removed to keep the configmap clean.
+
+## Managing the ConfigMap
+
+Once a migration is completed, the migration script in `migration-configmap.yaml` can be removed. Completed migrations
+should be moved to the `completed-migrations` directory. To prevent the migration configmap from getting too large, only
+the latest release's migration should be stored there. The file should be renamed to the release version, e.g. `database-migration-v1.2.3.yaml`

--- a/test/flyway/completed-migrations/db-migration-v0.yaml
+++ b/test/flyway/completed-migrations/db-migration-v0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: migration-configmap
+  namespace: flyway
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+data:
+  V1_2__update_test_table.sql: |
+    alter table migration_test.test_table
+    add another_col text;
+  V1_3__update_test_table_again.sql: |
+    alter table migration_test.test_table
+    add another_col_again text;

--- a/test/flyway/migration-configmap.yaml
+++ b/test/flyway/migration-configmap.yaml
@@ -6,9 +6,3 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: PreSync
 data:
-  V1_2__update_test_table.sql: |
-    alter table migration_test.test_table
-    add another_col text;
-  V1_3__update_test_table_again.sql: |
-    alter table migration_test.test_table
-    add another_col_again text;


### PR DESCRIPTION
In test
- Moves the demo migration to a prev-migration directory (this can be deleted once we have other examples)
- update readme

In acc
- adds flyway migration job to acc environment
