### PR TITLE
Upgrade AMI for nodegroups

### DIFF
--- a/acceptance/karpenter/nodegroup.yaml
+++ b/acceptance/karpenter/nodegroup.yaml
@@ -37,7 +37,7 @@ kind: EC2NodeClass
 metadata:
   name: default
 spec:
-  amiFamily: AL2 # Amazon Linux 2
+  amiFamily: AL2023
   role: "KarpenterNodeRole-dissco-k8s-acc"
   subnetSelectorTerms:
     - tags:
@@ -46,4 +46,4 @@ spec:
     - tags:
         karpenter.sh/discovery: "dissco-k8s-acc"
   amiSelectorTerms:
-    - alias: "al2@latest"
+    - alias: "al2023@latest"

--- a/production/karpenter/nodegroup.yaml
+++ b/production/karpenter/nodegroup.yaml
@@ -37,7 +37,7 @@ kind: EC2NodeClass
 metadata:
   name: default
 spec:
-  amiFamily: AL2 # Amazon Linux 2
+  amiFamily: AL2023
   role: "KarpenterNodeRole-dissco-k8s-production"
   subnetSelectorTerms:
     - tags:
@@ -46,4 +46,4 @@ spec:
     - tags:
         karpenter.sh/discovery: "dissco-k8s-production"
   amiSelectorTerms:
-    - alias: "al2@latest"
+    - alias: "al2023@latest"

--- a/production/traefik/deployment.yaml
+++ b/production/traefik/deployment.yaml
@@ -95,15 +95,6 @@ spec:
     spec:
       serviceAccountName: traefik-ingress-controller
       automountServiceAccountToken: true
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: eks.amazonaws.com/nodegroup
-                    operator: In
-                    values:
-                      - managed_nodes-20241127150956659200000016
       containers:
         - name: traefik
           image: traefik:v3.4

--- a/test/karpenter/nodegroup.yaml
+++ b/test/karpenter/nodegroup.yaml
@@ -34,7 +34,7 @@ kind: EC2NodeClass
 metadata:
   name: default
 spec:
-  amiFamily: AL2 # Amazon Linux 2
+  amiFamily: AL2023
   role: "KarpenterNodeRole-dissco-k8s-test"
   subnetSelectorTerms:
     - tags:

--- a/test/traefik/deployment.yaml
+++ b/test/traefik/deployment.yaml
@@ -95,15 +95,6 @@ spec:
     spec:
       serviceAccountName: traefik-ingress-controller
       automountServiceAccountToken: true
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: eks.amazonaws.com/nodegroup
-                    operator: In
-                    values:
-                      - managed_m5-20230823065304717700000010
       containers:
         - name: traefik
           image: traefik:v3.4


### PR DESCRIPTION
Fix Nodegroups to use the correct AMI family