### PR TITLE
DD-3019 Add report JsonB column to translator job record

### DIFF
--- a/test/flyway/completed-migrations/completed-migrations.yaml
+++ b/test/flyway/completed-migrations/completed-migrations.yaml
@@ -37,3 +37,6 @@ data:
         add source_system_id text;
     create index digital_media_source_system_id_index
         on digital_media_object (source_system_id);
+  V1_3_9__add_countries_column.sql: |
+    ALTER TABLE virtual_collection
+        ADD COLUMN countries text[];

--- a/test/flyway/migration-configmap.yaml
+++ b/test/flyway/migration-configmap.yaml
@@ -6,6 +6,6 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: PreSync
 data:
-  V1_3_9__add_countries_column.sql: |
-    ALTER TABLE virtual_collection
-    ADD COLUMN countries text[];
+  V1_4_0__add_translator_report_column.sql: |
+    ALTER TABLE translator_job_record
+    ADD report jsonb;


### PR DESCRIPTION
Adding report column to the translator_job_record.
This is how it will look like (for Aves dataset, never knew we rejected 15 records!):
{
  "successfulMedia": 175241,
  "digitalMediaIssues": {},
  "successfulSpecimen": 291545,
  "digitalSpecimenIssues": {
    "BasisOfRecord 'OtherSpecimen' is not accepted": 15
  }
}
Keeping processed column although it does not really have a function anymore.

https://naturalis.atlassian.net/browse/DD-3019