### PR TITLE
policy

### DIFF
--- a/acceptance/rabbitmq/rabbitmq-policy-queue-length.yaml
+++ b/acceptance/rabbitmq/rabbitmq-policy-queue-length.yaml
@@ -8,7 +8,7 @@ spec:
   pattern: "^digital-media-relationship-tombstone*"
   applyTo: "queues"
   definition:
-    max-length: 10000000
+    max-length: 100000
     overflow: "drop-head" # Drop messages from head so we don't exceed limit
   rabbitmqClusterReference:
     name: rabbitmq-cluster

--- a/acceptance/rabbitmq/rabbitmq-policy-queue-length.yaml
+++ b/acceptance/rabbitmq/rabbitmq-policy-queue-length.yaml
@@ -1,0 +1,14 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: queue-length-policy
+  namespace: rabbitmq
+spec:
+  name: queue-length-policy
+  pattern: "^digital-media-relationship-tombstone*"
+  applyTo: "queues"
+  definition:
+    max-length: 10000000
+    overflow: "drop-head" # Drop messages from head so we don't exceed limit
+  rabbitmqClusterReference:
+    name: rabbitmq-cluster


### PR DESCRIPTION
Adds policy to keep queue length under control while we investigate the issue. 
Capped at 10 mil. Can reduce or use a queue size limit instead of message count but this seemed clearest. Messages at 25mil+ in each queue were taking down the cluster so this gives us lots of breathing room. 

Documentation: 
https://www.rabbitmq.com/docs/maxlength
https://www.rabbitmq.com/kubernetes/operator/using-topology-operator#queues-policies