### PR TITLE
add policy to object

### DIFF
--- a/acceptance/digital-media-object/digital-media-relationship-tombstone.yaml
+++ b/acceptance/digital-media-object/digital-media-relationship-tombstone.yaml
@@ -36,6 +36,8 @@ spec:
     dead-letter-exchange: digital-media-relationship-tombstone-exchange-dlq
     dead-letter-routing-key: digital-media-relationship-tombstone-dlq
     delivery-limit: 1
+    max-length: 100000
+    overflow: "drop-head" # Drop messages from head so we don't exceed limit
   rabbitmqClusterReference:
     name: rabbitmq-cluster
 ---


### PR DESCRIPTION
Turns out a rabbitmq entity can only have one policy at a time (see "danger" section)

https://www.rabbitmq.com/docs/policies#defining

This measure will keep this queue to 100k objects and keep acc stable while we investigate the issue further. 

