### PR TITLE
split specimen in 3 profiles

### DIFF
--- a/production/digital-specimen/digital-specimen-processor-event.yaml
+++ b/production/digital-specimen/digital-specimen-processor-event.yaml
@@ -149,10 +149,3 @@ spec:
         queueName: digital-media-relationship-tombstone-queue
       authenticationRef:
         name: keda-trigger-auth-rabbitmq-conn
-    - type: rabbitmq
-      metadata:
-        mode: QueueLength
-        value: "1"
-        queueName: digital-media-relationship-tombstone-queue
-      authenticationRef:
-        name: keda-trigger-auth-rabbitmq-conn

--- a/test/digital-specimen/digital-specimen-processor-er-event.yaml
+++ b/test/digital-specimen/digital-specimen-processor-er-event.yaml
@@ -1,30 +1,30 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dissco-digital-specimen-processor-event
+  name: dissco-digital-specimen-processor-er-event
   labels:
-    app: dissco-digital-specimen-processor-event
+    app: dissco-digital-specimen-processor-er-event
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dissco-digital-specimen-processor-event
+      app: dissco-digital-specimen-processor-er-event
   template:
     metadata:
       labels:
-        app: dissco-digital-specimen-processor-event
+        app: dissco-digital-specimen-processor-er-event
         language: java
     spec:
       automountServiceAccountToken: false
       containers:
-        - name: dissco-digital-specimen-processor-event
+        - name: dissco-digital-specimen-processor-er-event
           image: public.ecr.aws/dissco/dissco-core-digital-specimen-processor
           imagePullPolicy: Always
           ports:
             - containerPort: 80
           env:
             - name: spring.profiles.active
-              value: rabbitmq
+              value: er-rabbitmq
             - name: spring.datasource.url
               value: jdbc:postgresql://terraform-20230822143945532600000001.cbppwfnjypll.eu-west-2.rds.amazonaws.com:5432/dissco
             - name: spring.datasource.username
@@ -106,31 +106,6 @@ spec:
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: dissco-digital-specimen-processor-event-scaled-object
-spec:
-  scaleTargetRef:
-    name: dissco-digital-specimen-processor-event
-  minReplicaCount: 0
-  maxReplicaCount: 1
-  triggers:
-    - type: rabbitmq
-      metadata:
-        mode: QueueLength
-        value: "1"
-        queueName: digital-specimen-queue
-      authenticationRef:
-        name: keda-trigger-auth-rabbitmq-conn
-    - type: rabbitmq
-      metadata:
-        mode: QueueLength
-        value: "1"
-        queueName: digital-media-queue
-      authenticationRef:
-        name: keda-trigger-auth-rabbitmq-conn
----
-apiVersion: keda.sh/v1alpha1
-kind: ScaledObject
-metadata:
   name: digital-media-relationship-tombstone-event-scaled-object
 spec:
   scaleTargetRef:
@@ -138,13 +113,6 @@ spec:
   minReplicaCount: 0
   maxReplicaCount: 1
   triggers:
-    - type: rabbitmq
-      metadata:
-        mode: QueueLength
-        value: "1"
-        queueName: digital-media-relationship-tombstone-queue
-      authenticationRef:
-        name: keda-trigger-auth-rabbitmq-conn
     - type: rabbitmq
       metadata:
         mode: QueueLength

--- a/test/digital-specimen/digital-specimen-processor-media-event.yaml
+++ b/test/digital-specimen/digital-specimen-processor-media-event.yaml
@@ -1,32 +1,32 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dissco-digital-specimen-processor-event
+  name: dissco-digital-specimen-processor-media-event
   labels:
-    app: dissco-digital-specimen-processor-event
+    app: dissco-digital-specimen-processor-media-event
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dissco-digital-specimen-processor-event
+      app: dissco-digital-specimen-processor-media-event
   template:
     metadata:
       labels:
-        app: dissco-digital-specimen-processor-event
+        app: dissco-digital-specimen-processor-media-event
         language: java
     spec:
       automountServiceAccountToken: false
       containers:
-        - name: dissco-digital-specimen-processor-event
-          image: public.ecr.aws/dissco/dissco-core-digital-specimen-processor:sha-f130cd2   # Jan-27-2026
+        - name: dissco-digital-specimen-processor-media-event
+          image: public.ecr.aws/dissco/dissco-core-digital-specimen-processor
           imagePullPolicy: Always
           ports:
             - containerPort: 80
           env:
             - name: spring.profiles.active
-              value: rabbitmq
+              value: media-rabbitmq
             - name: spring.datasource.url
-              value: jdbc:postgresql://terraform-20230828064251677200000001.cbppwfnjypll.eu-west-2.rds.amazonaws.com:5432/dissco
+              value: jdbc:postgresql://terraform-20230822143945532600000001.cbppwfnjypll.eu-west-2.rds.amazonaws.com:5432/dissco
             - name: spring.datasource.username
               valueFrom:
                 secretKeyRef:
@@ -73,8 +73,8 @@ spec:
               value: client_credentials
             - name: spring.security.oauth2.client.provider.dissco.token-uri
               value: https://keycloak.iam.naturalis.io/realms/dissco-dev/protocol/openid-connect/token
-            - name: handle.endpoint
-              value: https://sandbox.dissco.tech/doi-manager/api/pids/v1
+            - name: doi.endpoint
+              value: https://dev.dissco.tech/doi-manager/api/pids/v1
             - name: spring.security.oauth2.client.registration.dissco.client-secret
               valueFrom:
                 secretKeyRef:
@@ -106,35 +106,10 @@ spec:
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: dissco-digital-specimen-processor-event-scaled-object
+  name: dissco-digital-specimen-processor-media-event-scaled-object
 spec:
   scaleTargetRef:
-    name: dissco-digital-specimen-processor-event
-  minReplicaCount: 0
-  maxReplicaCount:  1
-  triggers:
-    - type: rabbitmq
-      metadata:
-        mode: QueueLength
-        value: "1"
-        queueName: digital-specimen-queue
-      authenticationRef:
-        name: keda-trigger-auth-rabbitmq-conn
-    - type: rabbitmq
-      metadata:
-        mode: QueueLength
-        value: "1"
-        queueName: digital-media-queue
-      authenticationRef:
-        name: keda-trigger-auth-rabbitmq-conn
----
-apiVersion: keda.sh/v1alpha1
-kind: ScaledObject
-metadata:
-  name: digital-media-relationship-tombstone-event-scaled-object
-spec:
-  scaleTargetRef:
-    name: digital-media-relationship-tombstone-event
+    name: dissco-digital-specimen-processor-media-event
   minReplicaCount: 0
   maxReplicaCount: 1
   triggers:
@@ -142,6 +117,6 @@ spec:
       metadata:
         mode: QueueLength
         value: "1"
-        queueName: digital-media-relationship-tombstone-queue
+        queueName: digital-media-queue
       authenticationRef:
         name: keda-trigger-auth-rabbitmq-conn

--- a/test/digital-specimen/digital-specimen-processor-specimen-event.yaml
+++ b/test/digital-specimen/digital-specimen-processor-specimen-event.yaml
@@ -1,32 +1,32 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dissco-digital-specimen-processor-event
+  name: dissco-digital-specimen-processor-specimen-event
   labels:
-    app: dissco-digital-specimen-processor-event
+    app: dissco-digital-specimen-processor-specimen-event
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dissco-digital-specimen-processor-event
+      app: dissco-digital-specimen-processor-specimen-event
   template:
     metadata:
       labels:
-        app: dissco-digital-specimen-processor-event
+        app: dissco-digital-specimen-processor-specimen-event
         language: java
     spec:
       automountServiceAccountToken: false
       containers:
-        - name: dissco-digital-specimen-processor-event
-          image: public.ecr.aws/dissco/dissco-core-digital-specimen-processor:sha-f130cd2   # Jan-27-2026
+        - name: dissco-digital-specimen-processor-specimen-event
+          image: public.ecr.aws/dissco/dissco-core-digital-specimen-processor
           imagePullPolicy: Always
           ports:
             - containerPort: 80
           env:
             - name: spring.profiles.active
-              value: rabbitmq
+              value: specimen-rabbitmq
             - name: spring.datasource.url
-              value: jdbc:postgresql://terraform-20230828064251677200000001.cbppwfnjypll.eu-west-2.rds.amazonaws.com:5432/dissco
+              value: jdbc:postgresql://terraform-20230822143945532600000001.cbppwfnjypll.eu-west-2.rds.amazonaws.com:5432/dissco
             - name: spring.datasource.username
               valueFrom:
                 secretKeyRef:
@@ -73,8 +73,8 @@ spec:
               value: client_credentials
             - name: spring.security.oauth2.client.provider.dissco.token-uri
               value: https://keycloak.iam.naturalis.io/realms/dissco-dev/protocol/openid-connect/token
-            - name: handle.endpoint
-              value: https://sandbox.dissco.tech/doi-manager/api/pids/v1
+            - name: doi.endpoint
+              value: https://dev.dissco.tech/doi-manager/api/pids/v1
             - name: spring.security.oauth2.client.registration.dissco.client-secret
               valueFrom:
                 secretKeyRef:
@@ -106,35 +106,10 @@ spec:
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: dissco-digital-specimen-processor-event-scaled-object
+  name: dissco-digital-specimen-processor-specimen-event-scaled-object
 spec:
   scaleTargetRef:
-    name: dissco-digital-specimen-processor-event
-  minReplicaCount: 0
-  maxReplicaCount:  1
-  triggers:
-    - type: rabbitmq
-      metadata:
-        mode: QueueLength
-        value: "1"
-        queueName: digital-specimen-queue
-      authenticationRef:
-        name: keda-trigger-auth-rabbitmq-conn
-    - type: rabbitmq
-      metadata:
-        mode: QueueLength
-        value: "1"
-        queueName: digital-media-queue
-      authenticationRef:
-        name: keda-trigger-auth-rabbitmq-conn
----
-apiVersion: keda.sh/v1alpha1
-kind: ScaledObject
-metadata:
-  name: digital-media-relationship-tombstone-event-scaled-object
-spec:
-  scaleTargetRef:
-    name: digital-media-relationship-tombstone-event
+    name: dissco-digital-specimen-processor-specimen-event
   minReplicaCount: 0
   maxReplicaCount: 1
   triggers:
@@ -142,6 +117,6 @@ spec:
       metadata:
         mode: QueueLength
         value: "1"
-        queueName: digital-media-relationship-tombstone-queue
+        queueName: digital-specimen-queue
       authenticationRef:
         name: keda-trigger-auth-rabbitmq-conn


### PR DESCRIPTION
Creates 3 deployments for specimen processor, each with their own keda scaled object

Also removes redundant trigger for media tombstone er queue in acc and prod. 