### PR TITLE
increase node count by 1

### DIFF
--- a/production/elastic/elasticsearch.yaml
+++ b/production/elastic/elasticsearch.yaml
@@ -7,7 +7,7 @@ spec:
   version: 9.2.0
   nodeSets:
     - name: default
-      count: 3
+      count: 4
       config:
         node.store.allow_mmap: false
       volumeClaimTemplates:


### PR DESCRIPTION
https://www.elastic.co/docs/troubleshoot/elasticsearch/increase-capacity-data-node#increase-disk-capacity-of-data-nodes

ES suggests either adding nodes or increasing the storage size. I want to try adding nodes first, as I don't think our setup supports increasing volume size. 

This is not a long term solution. We really need to look into how to reduce the number of annotations being indexed, if we still want to index them at all. 


