### PR TITLE
add trailing slash

### DIFF
--- a/acceptance/datacite-publisher/datacite-publisher.yaml
+++ b/acceptance/datacite-publisher/datacite-publisher.yaml
@@ -44,7 +44,7 @@ spec:
                   name: aws-secrets
                   key: dissco-processing-service-client-secret
             - name: datacite.endpoint
-              value: https://api.test.datacite.org/dois
+              value: https://api.test.datacite.org/dois/
             - name: pid.endpoint
               value: https://sandbox.dissco.tech/doi-manager/api/pids/v1/
             - name: datacite.repository-id

--- a/production/datacite-publisher/datacite-publisher-deployment-web.yaml
+++ b/production/datacite-publisher/datacite-publisher-deployment-web.yaml
@@ -1,24 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: datacite-publisher
+  name: datacite-publisher-web
   labels:
-    app: datacite-publisher
+    app: datacite-publisher-web
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: datacite-publisher
+      app: datacite-publisher-web
   template:
     metadata:
       labels:
-        app: datacite-publisher
+        app: datacite-publisher-web
         language: java
     spec:
       serviceAccountName: secret-manager
       automountServiceAccountToken: false
       containers:
-        - name: datacite-publisher
+        - name: datacite-publisher-web
           image: public.ecr.aws/dissco/datacite-publisher:sha-167bccf   # Apr-16-2026
           imagePullPolicy: Always
           ports:
@@ -31,7 +31,7 @@ spec:
             - name: doi.landing-page-media
               value: 'https://disscover.dissco.eu/dm/'
             - name: spring.profiles.active
-              value: publish
+              value: web
             - name: spring.security.oauth2.resourceserver.jwt.issuer-uri
               value: https://keycloak.iam.naturalis.io/realms/dissco
             - name: spring.security.oauth2.authorizationserver.endpoint.jwk-set-uri
@@ -92,35 +92,3 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: "aws-secrets"
----
-apiVersion: keda.sh/v1alpha1
-kind: ScaledObject
-metadata:
-  name: datacite-publisher-scaled-object
-spec:
-  scaleTargetRef:
-    name: datacite-publisher
-  minReplicaCount: 0
-  maxReplicaCount:  1
-  triggers:
-    - type: rabbitmq
-      metadata:
-        mode: QueueLength
-        value: "1"
-        queueName: specimen-doi-queue
-      authenticationRef:
-        name: keda-trigger-auth-rabbitmq-conn
-    - type: rabbitmq
-      metadata:
-        mode: QueueLength
-        value: "1"
-        queueName: media-doi-queue
-      authenticationRef:
-        name: keda-trigger-auth-rabbitmq-conn
-    - type: rabbitmq
-      metadata:
-        mode: QueueLength
-        value: "1"
-        queueName: tombstone-doi-queue
-      authenticationRef:
-        name: keda-trigger-auth-rabbitmq-conn

--- a/production/datacite-publisher/datacite-publisher-web-route.yaml
+++ b/production/datacite-publisher/datacite-publisher-web-route.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: datacite-publisher-web-route
+spec:
+  selector:
+    app: datacite-publisher-web
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/production/pid-manager/doi-manager-deployment.yaml
+++ b/production/pid-manager/doi-manager-deployment.yaml
@@ -93,13 +93,13 @@ spec:
             httpGet:
               path: /actuator/health/liveness
               port: 8080
-            initialDelaySeconds: 45
+            initialDelaySeconds: 90
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
-            initialDelaySeconds: 45
+            initialDelaySeconds: 90
             failureThreshold: 2
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
Fixes datacite publisher in acc and prod (though we don't actually publish anything in acc, it just consumes the messages, which is why this was only caught in prod)

- add trailing slash to datacite uri (and remove redundant "records" in pid uri)
- adds web profile (it was saved locally -- not sure if we want it up all the time though? 

